### PR TITLE
feat: Implement genexus_batch_read tool for LLM performance

### DIFF
--- a/src/GxMcp.Gateway/Routers/ObjectRouter.cs
+++ b/src/GxMcp.Gateway/Routers/ObjectRouter.cs
@@ -71,6 +71,9 @@ namespace GxMcp.Gateway.Routers
                 case "genexus_batch_edit":
                     return new { module = "Batch", action = "MultiEdit", items = args?["items"] };
 
+                case "genexus_batch_read":
+                    return new { module = "Batch", action = "BatchRead", items = args?["items"] };
+
                 default:
                     return null;
             }

--- a/src/GxMcp.Gateway/tool_definitions.json
+++ b/src/GxMcp.Gateway/tool_definitions.json
@@ -5,10 +5,19 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "query": { "type": "string", "description": "The search query." },
-        "limit": { "type": "integer", "description": "Max results (default 50).", "default": 50 }
+        "query": {
+          "type": "string",
+          "description": "The search query."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max results (default 50).",
+          "default": 50
+        }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     }
   },
   {
@@ -17,12 +26,59 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "name": { "type": "string", "description": "Object name." },
-        "part": { "type": "string", "description": "Part (Source, Rules, Events).", "default": "Source" },
-        "offset": { "type": "integer", "description": "Start line for pagination." },
-        "limit": { "type": "integer", "description": "Lines to read." }
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "part": {
+          "type": "string",
+          "description": "Part (Source, Rules, Events).",
+          "default": "Source"
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Start line for pagination."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Lines to read."
+        }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
+    }
+  },
+  {
+    "name": "genexus_batch_read",
+    "description": "Reads source code from multiple objects in a single call. Drastically improves context-gathering speed.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Object name."
+              },
+              "part": {
+                "type": "string",
+                "description": "Part (Source, Rules, Events).",
+                "default": "Source"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        }
+      },
+      "required": [
+        "items"
+      ]
     }
   },
   {
@@ -31,29 +87,80 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "name": { "type": "string", "description": "Object name." },
-        "part": { "type": "string", "description": "Part name (e.g. Source, Rules).", "default": "Source" },
-        "mode": { "type": "string", "enum": ["full", "patch"], "description": "Edit mode." },
-        "content": { "type": "string", "description": "New code or patch content." },
-        "context": { "type": "string", "description": "For patch mode: The exact text (old_string) to replace." },
-        "operation": { "type": "string", "enum": ["Replace", "Insert_After", "Append"], "description": "For patch mode: Operation to perform." },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "part": {
+          "type": "string",
+          "description": "Part name (e.g. Source, Rules).",
+          "default": "Source"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "full",
+            "patch"
+          ],
+          "description": "Edit mode."
+        },
+        "content": {
+          "type": "string",
+          "description": "New code or patch content."
+        },
+        "context": {
+          "type": "string",
+          "description": "For patch mode: The exact text (old_string) to replace."
+        },
+        "operation": {
+          "type": "string",
+          "enum": [
+            "Replace",
+            "Insert_After",
+            "Append"
+          ],
+          "description": "For patch mode: Operation to perform."
+        },
         "changes": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "part": { "type": "string" },
-              "mode": { "type": "string", "enum": ["full", "patch"] },
-              "content": { "type": "string" },
-              "context": { "type": "string" },
-              "operation": { "type": "string", "enum": ["Replace", "Insert_After", "Append"] }
+              "part": {
+                "type": "string"
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "full",
+                  "patch"
+                ]
+              },
+              "content": {
+                "type": "string"
+              },
+              "context": {
+                "type": "string"
+              },
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "Replace",
+                  "Insert_After",
+                  "Append"
+                ]
+              }
             },
-            "required": ["content"]
+            "required": [
+              "content"
+            ]
           },
           "description": "Batch of changes to apply to this object."
         }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     }
   },
   {
@@ -67,29 +174,66 @@
           "items": {
             "type": "object",
             "properties": {
-              "name": { "type": "string", "description": "Target object name." },
+              "name": {
+                "type": "string",
+                "description": "Target object name."
+              },
               "changes": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "part": { "type": "string", "description": "Part name (Source, Rules, Events).", "default": "Source" },
-                    "mode": { "type": "string", "enum": ["full", "patch"], "description": "Edit mode.", "default": "patch" },
-                    "content": { "type": "string", "description": "New code or patch content." },
-                    "context": { "type": "string", "description": "For patch mode: exact text to replace." },
-                    "operation": { "type": "string", "enum": ["Replace", "Insert_After", "Append"], "description": "Patch operation.", "default": "Replace" }
+                    "part": {
+                      "type": "string",
+                      "description": "Part name (Source, Rules, Events).",
+                      "default": "Source"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "full",
+                        "patch"
+                      ],
+                      "description": "Edit mode.",
+                      "default": "patch"
+                    },
+                    "content": {
+                      "type": "string",
+                      "description": "New code or patch content."
+                    },
+                    "context": {
+                      "type": "string",
+                      "description": "For patch mode: exact text to replace."
+                    },
+                    "operation": {
+                      "type": "string",
+                      "enum": [
+                        "Replace",
+                        "Insert_After",
+                        "Append"
+                      ],
+                      "description": "Patch operation.",
+                      "default": "Replace"
+                    }
                   },
-                  "required": ["content"]
+                  "required": [
+                    "content"
+                  ]
                 },
                 "description": "Changes to apply to this object."
               }
             },
-            "required": ["name", "changes"]
+            "required": [
+              "name",
+              "changes"
+            ]
           },
           "description": "Array of objects to edit, each with its own changes."
         }
       },
-      "required": ["items"]
+      "required": [
+        "items"
+      ]
     }
   },
   {
@@ -98,14 +242,27 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "name": { "type": "string", "description": "Object name." },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
         "include": {
           "type": "array",
-          "items": { "type": "string", "enum": ["metadata", "variables", "signature", "structure"] },
+          "items": {
+            "type": "string",
+            "enum": [
+              "metadata",
+              "variables",
+              "signature",
+              "structure"
+            ]
+          },
           "description": "Specific parts to include (defaults to all)."
         }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     }
   },
   {
@@ -114,14 +271,28 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "name": { "type": "string", "description": "Object name." },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
         "mode": {
           "type": "string",
-          "enum": ["linter", "navigation", "hierarchy", "impact", "data_context", "ui_context", "pattern_metadata"],
+          "enum": [
+            "linter",
+            "navigation",
+            "hierarchy",
+            "impact",
+            "data_context",
+            "ui_context",
+            "pattern_metadata"
+          ],
           "description": "The type of analysis to perform."
         }
       },
-      "required": ["name", "mode"]
+      "required": [
+        "name",
+        "mode"
+      ]
     }
   },
   {
@@ -130,9 +301,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "name": { "type": "string", "description": "Object name." }
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     }
   },
   {
@@ -141,10 +317,19 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "name": { "type": "string", "description": "Object name." },
-        "recursive": { "type": "boolean", "description": "Whether to discover dependencies of dependencies (default: false).", "default": false }
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "recursive": {
+          "type": "boolean",
+          "description": "Whether to discover dependencies of dependencies (default: false).",
+          "default": false
+        }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     }
   },
   {
@@ -153,11 +338,30 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "action": { "type": "string", "enum": ["build", "rebuild", "validate", "sync", "index", "status"], "description": "Lifecycle action." },
-        "target": { "type": "string", "description": "Object or environment name." },
-        "code": { "type": "string", "description": "For validation: the code to check." }
+        "action": {
+          "type": "string",
+          "enum": [
+            "build",
+            "rebuild",
+            "validate",
+            "sync",
+            "index",
+            "status"
+          ],
+          "description": "Lifecycle action."
+        },
+        "target": {
+          "type": "string",
+          "description": "Object or environment name."
+        },
+        "code": {
+          "type": "string",
+          "description": "For validation: the code to check."
+        }
       },
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     }
   },
   {
@@ -166,12 +370,31 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "action": { "type": "string", "enum": ["scaffold", "translate", "sample"], "description": "Generation action." },
-        "type": { "type": "string", "description": "Object type (e.g. Prc, Trn)." },
-        "name": { "type": "string", "description": "Object name." },
-        "content": { "type": "string", "description": "Initial code or target language." }
+        "action": {
+          "type": "string",
+          "enum": [
+            "scaffold",
+            "translate",
+            "sample"
+          ],
+          "description": "Generation action."
+        },
+        "type": {
+          "type": "string",
+          "description": "Object type (e.g. Prc, Trn)."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "content": {
+          "type": "string",
+          "description": "Initial code or target language."
+        }
       },
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     }
   },
   {
@@ -180,9 +403,14 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "name": { "type": "string", "description": "Test object name." }
+        "name": {
+          "type": "string",
+          "description": "Test object name."
+        }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     }
   },
   {
@@ -191,10 +419,23 @@
     "inputSchema": {
       "type": "object",
       "properties": {
-        "action": { "type": "string", "enum": ["wiki", "visualize", "health"], "description": "Documentation action." },
-        "target": { "type": "string", "description": "Object or domain name." }
+        "action": {
+          "type": "string",
+          "enum": [
+            "wiki",
+            "visualize",
+            "health"
+          ],
+          "description": "Documentation action."
+        },
+        "target": {
+          "type": "string",
+          "description": "Object or domain name."
+        }
       },
-      "required": ["action"]
+      "required": [
+        "action"
+      ]
     }
   }
 ]

--- a/src/GxMcp.Worker/Services/BatchService.cs
+++ b/src/GxMcp.Worker/Services/BatchService.cs
@@ -9,13 +9,15 @@ namespace GxMcp.Worker.Services
         private readonly KbService _kbService;
         private readonly WriteService _writeService;
         private readonly PatchService _patchService;
+        private readonly ObjectService _objectService;
         private readonly List<BatchItem> _buffer = new List<BatchItem>();
 
-        public BatchService(KbService kbService, WriteService writeService, PatchService patchService)
+        public BatchService(KbService kbService, WriteService writeService, PatchService patchService, ObjectService objectService)
         {
             _kbService = kbService;
             _writeService = writeService;
             _patchService = patchService;
+            _objectService = objectService;
         }
 
         public string BatchEdit(string target, JArray changes)
@@ -127,6 +129,43 @@ namespace GxMcp.Worker.Services
             catch (Exception ex)
             {
                 return "{\"error\":\"MultiEdit failed: " + CommandDispatcher.EscapeJsonString(ex.Message) + "\"}";
+            }
+        }
+        public string BatchRead(JArray items)
+        {
+            try
+            {
+                if (items == null || items.Count == 0) return "{\"error\":\"No items provided\"}";
+
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                var results = new JArray();
+
+                foreach (var item in items)
+                {
+                    string name = item["name"]?.ToString();
+                    string part = item["part"]?.ToString() ?? "Source";
+                    if (string.IsNullOrEmpty(name)) continue;
+
+                    string readResult = _objectService.ReadObjectSource(name, part, null, null, "mcp");
+                    try {
+                        var parsed = JObject.Parse(readResult);
+                        parsed["object"] = name;
+                        results.Add(parsed);
+                    } catch {
+                        results.Add(new JObject { ["object"] = name, ["error"] = readResult });
+                    }
+                }
+
+                return new JObject {
+                    ["status"] = "Success",
+                    ["count"] = results.Count,
+                    ["results"] = results,
+                    ["duration"] = sw.ElapsedMilliseconds
+                }.ToString();
+            }
+            catch (Exception ex)
+            {
+                return "{\"error\":\"BatchRead failed: " + CommandDispatcher.EscapeJsonString(ex.Message) + "\"}";
             }
         }
     }

--- a/src/GxMcp.Worker/Services/CommandDispatcher.cs
+++ b/src/GxMcp.Worker/Services/CommandDispatcher.cs
@@ -68,7 +68,7 @@ namespace GxMcp.Worker.Services
             _writeService = new WriteService(_objectService);
             _refactorService = new RefactorService(_kbService, _objectService, _indexCacheService);
             _patchService = new PatchService(_objectService, _writeService);
-            _batchService = new BatchService(_kbService, _writeService, _patchService);
+            _batchService = new BatchService(_kbService, _writeService, _patchService, _objectService);
             _forgeService = new ForgeService(_kbService);
             _testService = new TestService(_kbService, _buildService);
             _wikiService = new WikiService(_objectService, _searchService);


### PR DESCRIPTION
Adds a new `genexus_batch_read` tool that allows an LLM to request the source code of multiple GeneXus objects in a single API call. This drastically improves LLM context-gathering speed and reduces the number of round-trips needed for reasoning tasks.
- Added tool to `tool_definitions.json`
- Mapped in `ObjectRouter.cs`
- Handled in `CommandDispatcher.cs` and `BatchService.cs`

---
*PR created automatically by Jules for task [9031121895779352679](https://jules.google.com/task/9031121895779352679) started by @lennix1337*