### PR TITLE
fix: stabilize genexus_edit on WebPanel Events (issue #8)

### DIFF
--- a/src/GxMcp.Gateway/Program.cs
+++ b/src/GxMcp.Gateway/Program.cs
@@ -35,6 +35,7 @@ namespace GxMcp.Gateway
         private static ConcurrentDictionary<string, JObject> _semanticCache = new ConcurrentDictionary<string, JObject>();
         private static HttpSessionRegistry _httpSessions = new HttpSessionRegistry(TimeSpan.FromMinutes(10));
         private static readonly OperationTracker _operationTracker = new OperationTracker(TimeSpan.FromMinutes(60));
+        private static int _workerWarmupStarted;
         private static readonly TimeSpan _pendingRequestRetention = TimeSpan.FromMinutes(65);
         private static readonly string _logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "gateway_debug.log");
         private static readonly BlockingCollection<string> _logQueue = new BlockingCollection<string>();
@@ -749,6 +750,10 @@ namespace GxMcp.Gateway
             var mcpResponse = McpRouter.Handle(request);
             if (mcpResponse != null)
             {
+                if (string.Equals(method, "initialize", StringComparison.OrdinalIgnoreCase))
+                {
+                    TriggerWorkerWarmupOnce();
+                }
                 return new JObject { ["jsonrpc"] = "2.0", ["id"] = idToken?.DeepClone(), ["result"] = JToken.FromObject(mcpResponse) };
             }
 
@@ -979,6 +984,112 @@ namespace GxMcp.Gateway
             }
             
             return null;
+        }
+
+        private static void TriggerWorkerWarmupOnce()
+        {
+            if (Interlocked.CompareExchange(ref _workerWarmupStarted, 1, 0) != 0)
+            {
+                return;
+            }
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    if (_worker == null)
+                    {
+                        Log("[Warmup] Worker not available, skipping warmup.");
+                        return;
+                    }
+
+                    Log("[Warmup] Starting worker warmup sequence...");
+                    BroadcastNotification("notifications/message", new
+                    {
+                        level = "info",
+                        logger = "warmup",
+                        data = "Worker warmup started.",
+                        timestamp = DateTime.UtcNow
+                    });
+
+                    var listCommand = new JObject
+                    {
+                        ["module"] = "List",
+                        ["action"] = "Objects",
+                        ["target"] = string.Empty,
+                        ["limit"] = 1,
+                        ["offset"] = 0,
+                        ["client"] = "mcp"
+                    };
+
+                    var listResponse = await SendWorkerCommandAsync(
+                        listCommand,
+                        30000,
+                        "Warmup list timeout",
+                        workerResponse => workerResponse,
+                        (_, correlationId) => new JObject
+                        {
+                            ["error"] = new JObject
+                            {
+                                ["message"] = "Warmup list operation timed out.",
+                                ["correlationId"] = correlationId
+                            }
+                        },
+                        toolName: "gateway_warmup_list",
+                        trackOperation: false);
+
+                    string? objectName = listResponse?["result"]?["results"]?.First?["name"]?.ToString();
+                    if (!string.IsNullOrWhiteSpace(objectName))
+                    {
+                        var readCommand = new JObject
+                        {
+                            ["module"] = "Read",
+                            ["action"] = "ExtractSource",
+                            ["target"] = objectName,
+                            ["part"] = "Source",
+                            ["offset"] = 0,
+                            ["limit"] = 1,
+                            ["client"] = "mcp"
+                        };
+
+                        await SendWorkerCommandAsync(
+                            readCommand,
+                            30000,
+                            "Warmup read timeout",
+                            workerResponse => workerResponse,
+                            (_, correlationId) => new JObject
+                            {
+                                ["error"] = new JObject
+                                {
+                                    ["message"] = "Warmup read operation timed out.",
+                                    ["correlationId"] = correlationId
+                                }
+                            },
+                            toolName: "gateway_warmup_read",
+                            trackOperation: false);
+                    }
+
+                    Log("[Warmup] Worker warmup finished.");
+                    BroadcastNotification("notifications/message", new
+                    {
+                        level = "info",
+                        logger = "warmup",
+                        data = "Worker warmup finished.",
+                        timestamp = DateTime.UtcNow
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Log("[Warmup] Worker warmup failed: " + ex.Message);
+                    BroadcastNotification("notifications/message", new
+                    {
+                        level = "warning",
+                        logger = "warmup",
+                        data = "Worker warmup failed: " + ex.Message,
+                        timestamp = DateTime.UtcNow
+                    });
+                }
+            });
         }
 
         private static JToken TruncateResponseIfNeeded(JToken? result, string toolName)

--- a/src/GxMcp.Gateway/Routers/ObjectRouter.cs
+++ b/src/GxMcp.Gateway/Routers/ObjectRouter.cs
@@ -54,7 +54,8 @@ namespace GxMcp.Gateway.Routers
                             content = args?["content"]?.ToString(),
                             context = args?["context"]?.ToString(),
                             expectedCount = args?["expectedCount"]?.ToObject<int?>() ?? 1,
-                            dryRun = args?["dryRun"]?.ToObject<bool?>() ?? false
+                            dryRun = args?["dryRun"]?.ToObject<bool?>() ?? false,
+                            verifyRollback = args?["verifyRollback"]?.ToObject<bool?>() ?? false
                         };
                     }
                     else
@@ -75,7 +76,8 @@ namespace GxMcp.Gateway.Routers
                         content = args?["content"]?.ToString(),
                         context = args?["context"]?.ToString(),
                         expectedCount = args?["expectedCount"]?.ToObject<int?>() ?? 1,
-                        dryRun = args?["dryRun"]?.ToObject<bool?>() ?? false
+                        dryRun = args?["dryRun"]?.ToObject<bool?>() ?? false,
+                        verifyRollback = args?["verifyRollback"]?.ToObject<bool?>() ?? false
                     };
                 case "genexus_write_object":
                     return new { module = "Write", action = part, target = target, payload = args?["code"]?.ToString() };

--- a/src/GxMcp.Gateway/tool_definitions.json
+++ b/src/GxMcp.Gateway/tool_definitions.json
@@ -177,6 +177,11 @@
           "description": "For patch mode: validates and computes patch result without persisting changes.",
           "default": false
         },
+        "verifyRollback": {
+          "type": "boolean",
+          "description": "For patch mode: applies the patch, verifies persisted content, then automatically restores the original content and verifies the rollback.",
+          "default": false
+        },
         "changes": {
           "type": "array",
           "items": {
@@ -214,6 +219,11 @@
               "dryRun": {
                 "type": "boolean",
                 "description": "For patch mode: validates patch without persisting.",
+                "default": false
+              },
+              "verifyRollback": {
+                "type": "boolean",
+                "description": "For patch mode: applies change, verifies persistence, and automatically rolls back to original content.",
                 "default": false
               }
             },
@@ -293,6 +303,11 @@
                     "dryRun": {
                       "type": "boolean",
                       "description": "For patch mode: validates patch without persisting.",
+                      "default": false
+                    },
+                    "verifyRollback": {
+                      "type": "boolean",
+                      "description": "For patch mode: applies change, verifies persistence, and automatically rolls back to original content.",
                       "default": false
                     }
                   },

--- a/src/GxMcp.Worker.Tests/PartAccessorAndWriteServiceTests.cs
+++ b/src/GxMcp.Worker.Tests/PartAccessorAndWriteServiceTests.cs
@@ -47,11 +47,14 @@ namespace GxMcp.Worker.Tests
 
         [Theory]
         [InlineData("Events", "Erro", "", true)]
+        [InlineData("Events", "Erro, line: 1", "", true)]
+        [InlineData("Events", "Error, line: 1", "", true)]
         [InlineData("Source", "Part save failed: Erro", "Erro", true)]
         [InlineData("Code", "", "", true)]
         [InlineData("Rules", "Erro", "", false)]
         [InlineData("Events", "Validation failed", "", false)]
         [InlineData("Events", "Erro", "Detailed SDK message", false)]
+        [InlineData("Events", "Erro, line: 1", "Detailed SDK message", false)]
         public void ShouldRetryWithoutPartSave_ShouldOnlyRetryGenericLogicalSourceFailures(string partName, string exceptionMessage, string diagnosticText, bool expected)
         {
             Assert.Equal(expected, WritePolicy.ShouldRetryWithoutPartSave(partName, exceptionMessage, diagnosticText));

--- a/src/GxMcp.Worker/Services/CommandDispatcher.cs
+++ b/src/GxMcp.Worker/Services/CommandDispatcher.cs
@@ -234,7 +234,8 @@ namespace GxMcp.Worker.Services
                             args?["context"]?.ToString(),
                             args?["expectedCount"]?.ToObject<int?>() ?? 1,
                             args?["type"]?.ToString(),
-                            args?["dryRun"]?.ToObject<bool?>() ?? false);
+                            args?["dryRun"]?.ToObject<bool?>() ?? false,
+                            args?["verifyRollback"]?.ToObject<bool?>() ?? false);
                         break;
                     case "analyze":
                         if (action == "GetNavigation") return _navigationService.GetNavigation(target);

--- a/src/GxMcp.Worker/Services/ObjectService.cs
+++ b/src/GxMcp.Worker/Services/ObjectService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Artech.Architecture.Common.Objects;
 using Artech.Architecture.Common.Descriptors;
@@ -16,6 +17,16 @@ namespace GxMcp.Worker.Services
 {
     public class ObjectService
     {
+        private sealed class ReadCacheEntry
+        {
+            public string Payload { get; set; } = string.Empty;
+            public DateTime UpdatedUtc { get; set; }
+        }
+
+        private static readonly ConcurrentDictionary<string, ReadCacheEntry> _readCache =
+            new ConcurrentDictionary<string, ReadCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        private static readonly TimeSpan ReadCacheTtl = TimeSpan.FromSeconds(20);
+
         private readonly KbService _kbService;
         private readonly BuildService _buildService;
         private DataInsightService _dataInsightService;
@@ -269,7 +280,54 @@ namespace GxMcp.Worker.Services
         {
             var obj = FindObject(target, typeFilter);
             if (obj == null) return HealingService.FormatNotFoundError(target, GetIndex());
-            return ReadObjectSourceInternal(obj, partName, offset, limit, client, minimize);
+
+            string resolvedPart = ResolvePartName(obj, partName);
+            if (ShouldUseReadCache(client, minimize))
+            {
+                string cacheKey = BuildReadCacheKey(obj.Guid, resolvedPart, offset, limit, client, minimize);
+                if (TryGetReadCache(cacheKey, out string cachedPayload))
+                {
+                    return cachedPayload;
+                }
+
+                string payload = ReadObjectSourceInternal(obj, resolvedPart, offset, limit, client, minimize);
+                if (CanCachePayload(payload))
+                {
+                    SetReadCache(cacheKey, payload);
+                }
+
+                return payload;
+            }
+
+            return ReadObjectSourceInternal(obj, resolvedPart, offset, limit, client, minimize);
+        }
+
+        public void MarkReadCacheDirty(KBObject obj, string partName = null)
+        {
+            if (obj == null)
+            {
+                return;
+            }
+
+            string normalizedPart = string.IsNullOrWhiteSpace(partName) ? null : partName.Trim().ToLowerInvariant();
+            string objectPrefix = obj.Guid.ToString("N").ToLowerInvariant() + "|";
+            foreach (var key in _readCache.Keys)
+            {
+                if (!key.StartsWith(objectPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (normalizedPart != null && !key.StartsWith(objectPrefix + normalizedPart + "|", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                _readCache.TryRemove(key, out _);
+            }
+
+            // SDK object cache invalidation is expensive; do it only after writes.
+            InvalidateCache(obj);
         }
 
         public string ExportObjectToText(string target, string outputPath, string partName = null, string typeFilter = null, bool overwrite = false)
@@ -375,18 +433,12 @@ namespace GxMcp.Worker.Services
 
         private string ReadObjectSourceInternal(KBObject obj, string partName, int? offset = null, int? limit = null, string client = "ide", bool minimize = false)
         {
-            if (string.IsNullOrEmpty(partName))
-            {
-                if (obj is Procedure) partName = "Source";
-                else if (obj is Transaction || obj is WebPanel) partName = "Events";
-                else partName = "Source";
-            }
+            partName = ResolvePartName(obj, partName);
 
             Logger.Info($"ReadObjectSourceInternal: {obj.Name} (Part: {partName}, Client: {client})");
             var sw = Stopwatch.StartNew();
             try
             {
-                InvalidateCache(obj);
                 string targetName = obj.Name;
 
                 if (WebFormXmlHelper.IsVisualPart(partName))
@@ -519,6 +571,87 @@ namespace GxMcp.Worker.Services
             catch (Exception ex)
             {
                 return "{\"error\": \"" + CommandDispatcher.EscapeJsonString(ex.Message) + "\"}";
+            }
+        }
+
+        private static string ResolvePartName(KBObject obj, string partName)
+        {
+            if (!string.IsNullOrWhiteSpace(partName))
+            {
+                return partName;
+            }
+
+            if (obj is Procedure) return "Source";
+            if (obj is Transaction || obj is WebPanel) return "Events";
+            return "Source";
+        }
+
+        private static bool ShouldUseReadCache(string client, bool minimize)
+        {
+            return string.Equals(client, "mcp", StringComparison.OrdinalIgnoreCase) && !minimize;
+        }
+
+        private static string BuildReadCacheKey(Guid objectGuid, string partName, int? offset, int? limit, string client, bool minimize)
+        {
+            string normalizedPart = string.IsNullOrWhiteSpace(partName) ? "source" : partName.Trim().ToLowerInvariant();
+            string normalizedClient = string.IsNullOrWhiteSpace(client) ? "mcp" : client.Trim().ToLowerInvariant();
+            int normalizedOffset = offset ?? -1;
+            int normalizedLimit = limit ?? -1;
+            return objectGuid.ToString("N").ToLowerInvariant() + "|" + normalizedPart + "|" + normalizedOffset + "|" + normalizedLimit + "|" + normalizedClient + "|" + (minimize ? "1" : "0");
+        }
+
+        private static bool TryGetReadCache(string key, out string payload)
+        {
+            payload = string.Empty;
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return false;
+            }
+
+            if (!_readCache.TryGetValue(key, out var entry) || entry == null)
+            {
+                return false;
+            }
+
+            if (DateTime.UtcNow - entry.UpdatedUtc > ReadCacheTtl)
+            {
+                _readCache.TryRemove(key, out _);
+                return false;
+            }
+
+            payload = entry.Payload;
+            return !string.IsNullOrWhiteSpace(payload);
+        }
+
+        private static void SetReadCache(string key, string payload)
+        {
+            if (string.IsNullOrWhiteSpace(key) || string.IsNullOrWhiteSpace(payload))
+            {
+                return;
+            }
+
+            _readCache[key] = new ReadCacheEntry
+            {
+                Payload = payload,
+                UpdatedUtc = DateTime.UtcNow
+            };
+        }
+
+        private static bool CanCachePayload(string payload)
+        {
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return false;
+            }
+
+            try
+            {
+                var json = JObject.Parse(payload);
+                return json["error"] == null;
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/src/GxMcp.Worker/Services/PatchService.cs
+++ b/src/GxMcp.Worker/Services/PatchService.cs
@@ -1,14 +1,28 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
+using System.Diagnostics;
 using GxMcp.Worker.Helpers;
 using Newtonsoft.Json.Linq;
+using Artech.Architecture.Common.Objects;
+using GxMcp.Worker.Structure;
 
 namespace GxMcp.Worker.Services
 {
     public class PatchService
     {
+        private sealed class SourceCacheEntry
+        {
+            public string Source { get; set; }
+            public DateTime UpdatedUtc { get; set; }
+        }
+
+        private static readonly ConcurrentDictionary<string, SourceCacheEntry> _sourceCache =
+            new ConcurrentDictionary<string, SourceCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        private static readonly TimeSpan SourceCacheTtl = TimeSpan.FromSeconds(20);
+
         private readonly ObjectService _objectService;
         private readonly WriteService _writeService;
 
@@ -18,17 +32,38 @@ namespace GxMcp.Worker.Services
             _writeService = writeService;
         }
 
-        public string ApplyPatch(string target, string partName, string operation, string content, string context = null, int expectedCount = 1, string typeFilter = null, bool dryRun = false)
+        public string ApplyPatch(string target, string partName, string operation, string content, string context = null, int expectedCount = 1, string typeFilter = null, bool dryRun = false, bool verifyRollback = false)
         {
             try
             {
-                // 1. Read current content (requesting 'mcp' client for plain text)
-                string currentResponse = _objectService.ReadObjectSource(target, partName, client: "mcp", typeFilter: typeFilter);
-                if (currentResponse.Contains("\"error\"")) return currentResponse;
-                
-                var json = Newtonsoft.Json.Linq.JObject.Parse(currentResponse);
-                string originalSource = json["source"]?.ToString();
-                if (originalSource == null) return "{\"error\": \"Could not retrieve source for part: " + partName + "\"}";
+                string cacheKey = BuildCacheKey(target, partName, typeFilter);
+                bool sourceFromCache = false;
+                long readMs = 0;
+                string originalSource = TryGetCachedSource(cacheKey);
+                if (originalSource == null)
+                {
+                    var readStopwatch = Stopwatch.StartNew();
+                    string currentResponse = ReadSourceFast(target, partName, typeFilter);
+                    readStopwatch.Stop();
+                    readMs = readStopwatch.ElapsedMilliseconds;
+                    string readError = TryExtractError(currentResponse);
+                    if (!string.IsNullOrWhiteSpace(readError))
+                    {
+                        return Models.McpResponse.Error("Patch read failed", target, partName, readError);
+                    }
+
+                    var json = JObject.Parse(currentResponse);
+                    originalSource = json["source"]?.ToString();
+                    if (originalSource == null)
+                    {
+                        return Models.McpResponse.Error("Patch read failed", target, partName, "Could not retrieve source for requested part.");
+                    }
+                    UpdateCachedSource(cacheKey, originalSource);
+                }
+                else
+                {
+                    sourceFromCache = true;
+                }
 
                 // Normalize line endings for internal processing
                 string workSource = originalSource.Replace("\r\n", "\n").Replace("\r", "\n");
@@ -50,6 +85,7 @@ namespace GxMcp.Worker.Services
                     return BuildPatchResult("Error", partName, normalizedOperation, expectedCount, 0, "expectedCount must be >= 1.");
                 }
 
+                var patchStopwatch = Stopwatch.StartNew();
                 switch (normalizedOperation)
                 {
                     case "replace":
@@ -86,6 +122,44 @@ namespace GxMcp.Worker.Services
                     default:
                         return BuildPatchResult("Error", partName, normalizedOperation, expectedCount, 0, "Unknown operation: " + operation);
                 }
+                patchStopwatch.Stop();
+                long patchMs = patchStopwatch.ElapsedMilliseconds;
+
+                // One guarded retry against stale cache: refresh source once and recompute.
+                if (sourceFromCache &&
+                    string.IsNullOrEmpty(updatedSource) &&
+                    (string.Equals(status, "NoMatch", StringComparison.OrdinalIgnoreCase) ||
+                     string.Equals(status, "Ambiguous", StringComparison.OrdinalIgnoreCase)))
+                {
+                    var refreshReadSw = Stopwatch.StartNew();
+                    string refreshedResponse = ReadSourceFast(target, partName, typeFilter);
+                    refreshReadSw.Stop();
+                    readMs += refreshReadSw.ElapsedMilliseconds;
+                    string refreshedError = TryExtractError(refreshedResponse);
+                    if (string.IsNullOrWhiteSpace(refreshedError))
+                    {
+                        var refreshedJson = JObject.Parse(refreshedResponse);
+                        string refreshedSource = refreshedJson["source"]?.ToString();
+                        if (refreshedSource != null)
+                        {
+                            UpdateCachedSource(cacheKey, refreshedSource);
+                            originalSource = refreshedSource;
+                            workSource = originalSource.Replace("\r\n", "\n").Replace("\r", "\n");
+                            sourceLines = workSource.Split('\n');
+                            patchStopwatch.Restart();
+                            if (normalizedOperation == "replace")
+                            {
+                                updatedSource = TryReplace(sourceLines, contextLines ?? new string[0], workContent, expectedCount, out status, out details, out matchCount);
+                            }
+                            else if (normalizedOperation == "insert_after")
+                            {
+                                updatedSource = TryInsertAfter(sourceLines, contextLines ?? new string[0], workContent, expectedCount, out status, out details, out matchCount);
+                            }
+                            patchStopwatch.Stop();
+                            patchMs += patchStopwatch.ElapsedMilliseconds;
+                        }
+                    }
+                }
 
                 if (string.IsNullOrEmpty(updatedSource))
                 {
@@ -100,22 +174,28 @@ namespace GxMcp.Worker.Services
                     string failedDetails = string.IsNullOrWhiteSpace(details)
                         ? $"Context not found. Ensure the context matches a unique block in the source code.{dbg}"
                         : details;
-                    return BuildPatchResult(failedStatus, partName, normalizedOperation, expectedCount, matchCount, failedDetails);
+                    string failure = BuildPatchResult(failedStatus, partName, normalizedOperation, expectedCount, matchCount, failedDetails);
+                    return AttachTimings(failure, readMs, patchMs, 0, sourceFromCache);
                 }
 
                 if (NormalizeSourceForComparison(workSource) == NormalizeSourceForComparison(updatedSource))
                 {
-                    return BuildPatchResult("NoChange", partName, normalizedOperation, expectedCount, matchCount, "Patch produced no effective changes. Write skipped.");
+                    string noChange = BuildPatchResult("NoChange", partName, normalizedOperation, expectedCount, matchCount, "Patch produced no effective changes. Write skipped.");
+                    return AttachTimings(noChange, readMs, patchMs, 0, sourceFromCache);
                 }
 
                 if (dryRun)
                 {
-                    return BuildPatchResult("Applied", partName, normalizedOperation, expectedCount, matchCount, "Dry-run succeeded. Write skipped.");
+                    string dryRunResult = BuildPatchResult("Applied", partName, normalizedOperation, expectedCount, matchCount, "Dry-run succeeded. Write skipped.");
+                    return AttachTimings(dryRunResult, readMs, patchMs, 0, sourceFromCache);
                 }
 
                 // 3. Write Back (re-normalize to CRLF for GeneXus)
                 string finalCode = updatedSource.Replace("\n", Environment.NewLine);
-                string writeResult = _writeService.WriteObject(target, partName, finalCode, typeFilter);
+                var writeStopwatch = Stopwatch.StartNew();
+                string writeResult = _writeService.WriteObject(target, partName, finalCode, typeFilter, autoValidate: false, preferFastSourceSave: true, autoInjectVariables: false);
+                writeStopwatch.Stop();
+                long writeMs = writeStopwatch.ElapsedMilliseconds;
                 JObject writePayload;
                 try
                 {
@@ -126,10 +206,88 @@ namespace GxMcp.Worker.Services
                     writePayload = new JObject { ["status"] = "Error", ["error"] = writeResult };
                 }
 
+                if (string.Equals(writePayload["status"]?.ToString(), "Success", StringComparison.OrdinalIgnoreCase))
+                {
+                    UpdateCachedSource(cacheKey, finalCode);
+                }
+
+                if (verifyRollback && string.Equals(writePayload["status"]?.ToString(), "Success", StringComparison.OrdinalIgnoreCase))
+                {
+                    string verifyReadResponse = ReadSourceFast(target, partName, typeFilter);
+                    string verifyReadError = TryExtractError(verifyReadResponse);
+                    if (!string.IsNullOrWhiteSpace(verifyReadError))
+                    {
+                        writePayload["status"] = "Error";
+                        writePayload["error"] = "Apply verification read failed: " + verifyReadError;
+                        writePayload["verifyRollback"] = true;
+                    }
+                    else
+                    {
+                        var verifyJson = JObject.Parse(verifyReadResponse);
+                        string persistedSource = verifyJson["source"]?.ToString() ?? string.Empty;
+                        bool applyVerified = NormalizeSourceForComparison(persistedSource) == NormalizeSourceForComparison(finalCode);
+                        writePayload["applyVerified"] = applyVerified;
+                        writePayload["verifyRollback"] = true;
+                        if (!applyVerified)
+                        {
+                            writePayload["status"] = "Error";
+                            writePayload["error"] = "Apply verification mismatch: persisted content differs from patched content.";
+                        }
+                    }
+
+                    string rollbackWrite = _writeService.WriteObject(target, partName, originalSource, typeFilter, autoValidate: false, preferFastSourceSave: true, autoInjectVariables: false);
+                    JObject rollbackPayload;
+                    try
+                    {
+                        rollbackPayload = JObject.Parse(rollbackWrite);
+                    }
+                    catch
+                    {
+                        rollbackPayload = new JObject { ["status"] = "Error", ["error"] = rollbackWrite };
+                    }
+
+                    bool rollbackSuccess = string.Equals(rollbackPayload["status"]?.ToString(), "Success", StringComparison.OrdinalIgnoreCase);
+                    writePayload["rollbackStatus"] = rollbackPayload["status"]?.ToString() ?? "Error";
+                    if (!rollbackSuccess)
+                    {
+                        writePayload["status"] = "Error";
+                        writePayload["rollbackError"] = rollbackPayload["error"]?.ToString() ?? "Rollback failed.";
+                    }
+                    else
+                    {
+                        string rollbackReadResponse = ReadSourceFast(target, partName, typeFilter);
+                        string rollbackReadError = TryExtractError(rollbackReadResponse);
+                        if (!string.IsNullOrWhiteSpace(rollbackReadError))
+                        {
+                            writePayload["status"] = "Error";
+                            writePayload["rollbackError"] = "Rollback verification read failed: " + rollbackReadError;
+                        }
+                        else
+                        {
+                            var rollbackReadJson = JObject.Parse(rollbackReadResponse);
+                            string rollbackSource = rollbackReadJson["source"]?.ToString() ?? string.Empty;
+                            bool rollbackVerified = NormalizeSourceForComparison(rollbackSource) == NormalizeSourceForComparison(originalSource);
+                            writePayload["rollbackVerified"] = rollbackVerified;
+                            if (!rollbackVerified)
+                            {
+                                writePayload["status"] = "Error";
+                                writePayload["rollbackError"] = "Rollback verification mismatch: current content differs from original content.";
+                            }
+                        }
+                    }
+                }
+
                 writePayload["patchStatus"] = "Applied";
                 writePayload["operation"] = normalizedOperation;
                 writePayload["expectedCount"] = expectedCount;
                 writePayload["matchCount"] = matchCount;
+                writePayload["timings"] = new JObject
+                {
+                    ["readMs"] = readMs,
+                    ["patchMs"] = patchMs,
+                    ["writeMs"] = writeMs,
+                    ["usedSourceCache"] = sourceFromCache
+                };
                 return writePayload.ToString();
             }
             catch (Exception ex)
@@ -367,6 +525,121 @@ namespace GxMcp.Worker.Services
         {
             if (text == null) return string.Empty;
             return text.Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd('\n');
+        }
+
+        private static string TryExtractError(string response)
+        {
+            if (string.IsNullOrWhiteSpace(response)) return "Empty response.";
+
+            try
+            {
+                var json = JObject.Parse(response);
+                return json["error"]?.ToString();
+            }
+            catch
+            {
+                return "Non-JSON response.";
+            }
+        }
+
+        private string ReadSourceFast(string target, string partName, string typeFilter)
+        {
+            try
+            {
+                var obj = _objectService.FindObject(target, typeFilter);
+                if (obj == null)
+                {
+                    return Models.McpResponse.Error("Object not found", target, partName, "The requested object is not available in the active Knowledge Base.");
+                }
+
+                string resolvedPart = string.IsNullOrWhiteSpace(partName) ? "Source" : partName;
+                KBObjectPart part = PartAccessor.GetPart(obj, resolvedPart);
+                if (part == null)
+                {
+                    return Models.McpResponse.Error("Part not found", target, resolvedPart, "The object does not expose the requested part.");
+                }
+
+                string source = null;
+                if (part is ISource sourcePart)
+                {
+                    source = sourcePart.Source;
+                }
+                else
+                {
+                    var contentProp = part.GetType().GetProperty("Source") ?? part.GetType().GetProperty("Content");
+                    if (contentProp != null && contentProp.CanRead && contentProp.PropertyType == typeof(string))
+                    {
+                        source = contentProp.GetValue(part)?.ToString();
+                    }
+                }
+
+                if (source == null)
+                {
+                    return Models.McpResponse.Error("Part does not expose text source", target, resolvedPart, "Patch operations require a textual part.");
+                }
+
+                return new JObject
+                {
+                    ["status"] = "Success",
+                    ["part"] = resolvedPart,
+                    ["source"] = source
+                }.ToString();
+            }
+            catch (Exception ex)
+            {
+                return Models.McpResponse.Error("Patch read failed", target, partName, ex.Message);
+            }
+        }
+
+        private static string BuildCacheKey(string target, string partName, string typeFilter)
+        {
+            string normalizedTarget = target?.Trim() ?? string.Empty;
+            string normalizedPart = string.IsNullOrWhiteSpace(partName) ? "Source" : partName.Trim();
+            string normalizedType = typeFilter?.Trim() ?? string.Empty;
+            return normalizedType + "|" + normalizedTarget + "|" + normalizedPart;
+        }
+
+        private static string TryGetCachedSource(string cacheKey)
+        {
+            if (string.IsNullOrWhiteSpace(cacheKey)) return null;
+            if (!_sourceCache.TryGetValue(cacheKey, out var entry) || entry == null) return null;
+            if (DateTime.UtcNow - entry.UpdatedUtc > SourceCacheTtl)
+            {
+                _sourceCache.TryRemove(cacheKey, out _);
+                return null;
+            }
+
+            return entry.Source;
+        }
+
+        private static void UpdateCachedSource(string cacheKey, string source)
+        {
+            if (string.IsNullOrWhiteSpace(cacheKey) || source == null) return;
+            _sourceCache[cacheKey] = new SourceCacheEntry
+            {
+                Source = source,
+                UpdatedUtc = DateTime.UtcNow
+            };
+        }
+
+        private static string AttachTimings(string patchResultJson, long readMs, long patchMs, long writeMs, bool usedSourceCache)
+        {
+            try
+            {
+                var json = JObject.Parse(patchResultJson);
+                json["timings"] = new JObject
+                {
+                    ["readMs"] = readMs,
+                    ["patchMs"] = patchMs,
+                    ["writeMs"] = writeMs,
+                    ["usedSourceCache"] = usedSourceCache
+                };
+                return json.ToString();
+            }
+            catch
+            {
+                return patchResultJson;
+            }
         }
 
         private static string BuildPatchResult(string patchStatus, string partName, string operation, int expectedCount, int matchCount, string details)

--- a/src/GxMcp.Worker/Services/WritePolicy.cs
+++ b/src/GxMcp.Worker/Services/WritePolicy.cs
@@ -1,12 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
 namespace GxMcp.Worker.Services
 {
     public static class WritePolicy
     {
+        private static readonly Regex GenericLineErrorRegex = new Regex(
+            @"^(erro|error)\s*,\s*line\s*:\s*\d+\s*$",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
         public static bool IsUnchangedSourceWrite(string existingSource, string incomingSource) =>
             string.Equals(
                 NormalizeSourceForComparison(existingSource),
@@ -75,11 +80,18 @@ namespace GxMcp.Worker.Services
                 return false;
             }
 
+            string normalizedException = exceptionMessage?.Trim() ?? string.Empty;
+            string normalizedDiagnostic = diagnosticText?.Trim() ?? string.Empty;
+
             bool genericFailure = string.IsNullOrWhiteSpace(exceptionMessage) ||
-                                  string.Equals(exceptionMessage.Trim(), "Erro", StringComparison.OrdinalIgnoreCase) ||
+                                  string.Equals(normalizedException, "Erro", StringComparison.OrdinalIgnoreCase) ||
+                                  string.Equals(normalizedException, "Error", StringComparison.OrdinalIgnoreCase) ||
+                                  GenericLineErrorRegex.IsMatch(normalizedException) ||
                                   exceptionMessage.IndexOf("Part save failed: Erro", StringComparison.OrdinalIgnoreCase) >= 0;
             bool genericDiagnostics = string.IsNullOrWhiteSpace(diagnosticText) ||
-                                      string.Equals(diagnosticText.Trim(), "Erro", StringComparison.OrdinalIgnoreCase);
+                                      string.Equals(normalizedDiagnostic, "Erro", StringComparison.OrdinalIgnoreCase) ||
+                                      string.Equals(normalizedDiagnostic, "Error", StringComparison.OrdinalIgnoreCase) ||
+                                      GenericLineErrorRegex.IsMatch(normalizedDiagnostic);
             return genericFailure && genericDiagnostics;
         }
     }

--- a/src/GxMcp.Worker/Services/WriteService.cs
+++ b/src/GxMcp.Worker/Services/WriteService.cs
@@ -16,6 +16,8 @@ namespace GxMcp.Worker.Services
         private readonly ObjectService _objectService;
         private readonly PatternAnalysisService _patternAnalysisService;
         private ValidationService _validationService;
+        private static readonly object _persistenceWarmupLock = new object();
+        private static bool _persistenceWarmupDone = false;
         private static readonly object _flushLock = new object();
         private static System.Timers.Timer _flushTimer;
         private static bool _pendingCommit = false;
@@ -77,6 +79,30 @@ namespace GxMcp.Worker.Services
                 catch (Exception ex)
                 {
                     Logger.Error("[BACKGROUND-FLUSH] ERROR: " + ex.Message);
+                }
+            }
+        }
+
+        private void EnsurePersistenceWarmup()
+        {
+            if (_persistenceWarmupDone) return;
+
+            lock (_persistenceWarmupLock)
+            {
+                if (_persistenceWarmupDone) return;
+                try
+                {
+                    var kb = _objectService.GetKbService().GetKB();
+                    if (kb == null) return;
+                    Logger.Info("[DEBUG-SAVE] Warming up persistence pipeline...");
+                    dynamic tx = kb.BeginTransaction();
+                    tx.Commit();
+                    _persistenceWarmupDone = true;
+                    Logger.Info("[DEBUG-SAVE] Persistence warmup complete.");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warn("[DEBUG-SAVE] Persistence warmup failed: " + ex.Message);
                 }
             }
         }
@@ -167,7 +193,7 @@ namespace GxMcp.Worker.Services
             return errorRes;
         }
 
-        public string WriteObject(string target, string partName, string code, string typeFilter = null, bool autoValidate = true)
+        public string WriteObject(string target, string partName, string code, string typeFilter = null, bool autoValidate = true, bool preferFastSourceSave = false, bool autoInjectVariables = true)
         {
             try
             {
@@ -219,6 +245,7 @@ namespace GxMcp.Worker.Services
                             StructureParser.ParseFromText(objToUpdate, decodedCode);
                             objToUpdate.EnsureSave();
                             ScheduleFlush();
+                            _objectService.MarkReadCacheDirty(objToUpdate, partName);
                             return Models.McpResponse.Success("Write", target, new JObject { ["details"] = "Structure DSL successfully applied" });
                         } catch (Exception ex) {
                             Logger.Error("[DEBUG-SAVE] Error parsing Structure DSL: " + ex.Message);
@@ -274,11 +301,14 @@ namespace GxMcp.Worker.Services
                     sourcePart.Source = decodedCode;
                     
                     // Auto-inject variables based on the new code (Optimized with Index)
-                    try {
-                        var index = _objectService.GetKbService().GetIndexCache().GetIndex();
-                        VariableInjector.InjectVariables(obj, decodedCode, index);
-                    } catch (Exception ex) {
-                        Logger.Warn("[DEBUG-SAVE] Auto-inject variables failed: " + ex.Message);
+                    if (autoInjectVariables)
+                    {
+                        try {
+                            var index = _objectService.GetKbService().GetIndexCache().GetIndex();
+                            VariableInjector.InjectVariables(obj, decodedCode, index);
+                        } catch (Exception ex) {
+                            Logger.Warn("[DEBUG-SAVE] Auto-inject variables failed: " + ex.Message);
+                        }
                     }
                     contentSet = true;
                 }
@@ -327,6 +357,42 @@ namespace GxMcp.Worker.Services
                 // 3. PERSISTENCE SEQUENCE
                 try
                 {
+                    EnsurePersistenceWarmup();
+
+                    if (preferFastSourceSave &&
+                        part is global::Artech.Architecture.Common.Objects.ISource &&
+                        WritePolicy.IsLogicalSourcePart(partName))
+                    {
+                        try
+                        {
+                            var saveMethod = obj.GetType().GetMethod("Save", BindingFlags.Public | BindingFlags.Instance, null, Type.EmptyTypes, null);
+                            if (saveMethod != null)
+                            {
+                                Logger.Info("[DEBUG-SAVE] Fast persistence path: obj.Save() without explicit transaction.");
+                                saveMethod.Invoke(obj, null);
+                                ScheduleFlush();
+                                _objectService.MarkReadCacheDirty(obj, partName);
+                                return Models.McpResponse.Success("Write", target, new JObject
+                                {
+                                    ["fastPath"] = "save_without_transaction"
+                                });
+                            }
+
+                            Logger.Info("[DEBUG-SAVE] Fast persistence path fallback: obj.EnsureSave(false) without explicit transaction.");
+                            obj.EnsureSave(false);
+                            ScheduleFlush();
+                            _objectService.MarkReadCacheDirty(obj, partName);
+                            return Models.McpResponse.Success("Write", target, new JObject
+                            {
+                                ["fastPath"] = "ensure_save_without_transaction"
+                            });
+                        }
+                        catch (Exception fastEx)
+                        {
+                            Logger.Warn("[DEBUG-SAVE] Fast persistence path failed. Falling back to full transaction path. Reason: " + fastEx.Message);
+                        }
+                    }
+
                     var kb = _objectService.GetKbService().GetKB();
                     if (kb == null) throw new Exception("KB not opened");
 
@@ -349,28 +415,39 @@ namespace GxMcp.Worker.Services
                         failureStage = "part_save";
                         Logger.Info(string.Format("[DEBUG-SAVE] Invoking part.Save() for {0}...", part.TypeDescriptor?.Name));
                         bool skippedPartSave = false;
-                        try {
-                            part.Save();
-                            Logger.Info("[DEBUG-SAVE] part.Save() completed.");
-                        } catch (Exception exPart) {
-                            string partMsgs = GetSdkMessagesSafe(part);
-                            lastSdkMessages = partMsgs;
-                            var saveIssues = SdkDiagnosticsHelper.GetDiagnostics(obj);
-                            if (ShouldRetryWithoutPartSave(partName, part, exPart, partMsgs, saveIssues))
-                            {
-                                skippedPartSave = true;
-                                retryStrategy = "object_save_only";
-                                Logger.Warn($"[DEBUG-SAVE] part.Save() failed generically for {target} ({partName}). Retrying with object-level save only.");
-                            }
-                            else
-                            {
-                                string detailText = WritePolicy.BuildFailureDetails(partMsgs, saveIssues);
-                                Logger.Warn($"[DEBUG-SAVE] part.Save() threw exception: {exPart.Message}. Details: {detailText}");
-                                throw new Exception(
-                                    string.IsNullOrWhiteSpace(detailText)
-                                        ? $"Part save failed: {exPart.Message}"
-                                        : $"Part save failed: {exPart.Message}. Details: {detailText}",
-                                    exPart);
+                        if (preferFastSourceSave &&
+                            part is global::Artech.Architecture.Common.Objects.ISource &&
+                            WritePolicy.IsLogicalSourcePart(partName))
+                        {
+                            skippedPartSave = true;
+                            retryStrategy = "object_save_only_fast_path";
+                            Logger.Info($"[DEBUG-SAVE] Fast source save path enabled for {target} ({partName}). Skipping part.Save().");
+                        }
+                        else
+                        {
+                            try {
+                                part.Save();
+                                Logger.Info("[DEBUG-SAVE] part.Save() completed.");
+                            } catch (Exception exPart) {
+                                string partMsgs = GetSdkMessagesSafe(part);
+                                lastSdkMessages = partMsgs;
+                                var saveIssues = SdkDiagnosticsHelper.GetDiagnostics(obj);
+                                if (ShouldRetryWithoutPartSave(partName, part, exPart, partMsgs, saveIssues))
+                                {
+                                    skippedPartSave = true;
+                                    retryStrategy = "object_save_only";
+                                    Logger.Warn($"[DEBUG-SAVE] part.Save() failed generically for {target} ({partName}). Retrying with object-level save only.");
+                                }
+                                else
+                                {
+                                    string detailText = WritePolicy.BuildFailureDetails(partMsgs, saveIssues);
+                                    Logger.Warn($"[DEBUG-SAVE] part.Save() threw exception: {exPart.Message}. Details: {detailText}");
+                                    throw new Exception(
+                                        string.IsNullOrWhiteSpace(detailText)
+                                            ? $"Part save failed: {exPart.Message}"
+                                            : $"Part save failed: {exPart.Message}. Details: {detailText}",
+                                        exPart);
+                                }
                             }
                         }
 
@@ -425,6 +502,7 @@ namespace GxMcp.Worker.Services
                     ScheduleFlush();
 
                     Logger.Info("[DEBUG-SAVE] SAVE & COMMIT COMPLETE.");
+                    _objectService.MarkReadCacheDirty(obj, partName);
                     return Models.McpResponse.Success("Write", target);
                 }
                 catch (Exception saveEx)


### PR DESCRIPTION
## Summary
- handle generic "Erro/Error, line: N" retry path in write policy
- add fast save/read paths and selective cache invalidation
- add patch timings + short-lived source cache with stale-refresh retry
- warmup worker on gateway initialize to reduce cold-start latency
- keep patch path lean (skip validate/inject by default in patch writes)

## Validation
- dotnet test src/GxMcp.Worker.Tests/GxMcp.Worker.Tests.csproj --configuration Release --no-restore
- dotnet test src/GxMcp.Gateway.Tests/GxMcp.Gateway.Tests.csproj --configuration Release --no-restore

Fixes #8