### PR TITLE
fix(kb-explorer): scope folders by module to prevent cross-module merging

### DIFF
--- a/src/GxMcp.Worker/Services/IndexCacheService.cs
+++ b/src/GxMcp.Worker/Services/IndexCacheService.cs
@@ -156,6 +156,15 @@ namespace GxMcp.Worker.Services
                 return entry.Module;
             }
 
+            // When an entry lives inside a Folder under a Module, qualify the
+            // folder name with its parent module to preserve hierarchy. Without
+            // this, folders sharing names across modules (e.g. "Procs") collapse
+            // into a single bucket in the parent index.
+            if (!string.IsNullOrWhiteSpace(entry.Module))
+            {
+                return string.Format("{0}/{1}", entry.Module, entry.Parent);
+            }
+
             return entry.Parent;
         }
 

--- a/src/nexus-ide/src/gxFileSystem.ts
+++ b/src/nexus-ide/src/gxFileSystem.ts
@@ -661,8 +661,18 @@ export class GxFileSystemProvider implements vscode.FileSystemProvider {
             ? result
             : [];
 
-    const getEntryKey = (entry: any): string =>
-      `${String(entry?.type ?? "")}:${String(entry?.path ?? entry?.name ?? "")}`.toLowerCase();
+    const getEntryKey = (entry: any): string => {
+      const type = String(entry?.type ?? "").toLowerCase();
+      const path = typeof entry?.path === "string" ? entry.path.trim() : "";
+      if (path.length > 0) {
+        return `${type}:${path.toLowerCase()}`;
+      }
+      const parentPath = typeof entry?.parentPath === "string" ? entry.parentPath.trim() : "";
+      const name = String(entry?.name ?? "").toLowerCase();
+      return parentPath.length > 0
+        ? `${type}:${parentPath.toLowerCase()}/${name}`
+        : `${type}:${name}`;
+    };
 
     const getTypeSortBucket = (type: unknown): number => {
       const normalized = typeof type === "string" ? type.toLowerCase() : "";
@@ -779,6 +789,12 @@ export class GxFileSystemProvider implements vscode.FileSystemProvider {
 
       if (parentPath.length === 0) {
         return entryParent.length === 0 || entryParent === ROOT_PARENT_NAME;
+      }
+
+      // Nested parent: a name-only match is ambiguous across modules
+      // (e.g. ModuloA/Procs vs ModuloB/Procs). Require parentPath to disambiguate.
+      if (parentPath.includes("/")) {
+        return false;
       }
 
       return entryParent === parentName;


### PR DESCRIPTION
## Summary
- Dedupe key (`getEntryKey`) now includes `parentPath` when `path` is absent, so folders with the same name under different modules no longer collapse to a single entry.
- `isDirectChild` no longer falls back to name-only parent matching at nested depths, where `ModuloA/Procs` and `ModuloB/Procs` both carry `parent="Procs"` and were indistinguishable.
- Backend `InferLegacyParentPath` qualifies legacy folder entries with their `Module`, keeping the parent-index bucket scoped per module.

Closes #7

## Test plan
- [x] `tsc --noEmit` clean on `src/nexus-ide`
- [x] `dotnet build` clean on `GxMcp.Worker`
- [x] Existing unit test `Should browse children using parentPath instead of parent name` (extension.test.ts) already asserts that browsing `ModuloA` returns only the `ModuloA/Procs` folder and not `ModuloB/Procs`.
- [ ] Manual check in a KB containing folders with duplicate names across modules (e.g. `ModuloA/Procs`, `ModuloB/Procs`): each folder shows only its own objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)