### PR TITLE
chore(release): v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genexus-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A high-performance Model Context Protocol (MCP) server for GeneXus 18",
   "scripts": {
     "test": "node --test cli/run.test.js",


### PR DESCRIPTION
Bumps to v1.2.1. Includes fix #7 and the release workflow rework (#11). Merging to main should trigger the release workflow: test → npm publish → GitHub Release.