### PR TITLE
fix(worker): escape MSBuild XML + repair attribute rename index lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genexus-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A high-performance Model Context Protocol (MCP) server for GeneXus 18",
   "scripts": {
     "test": "node --test cli/run.test.js",

--- a/src/GxMcp.Worker/Services/BuildService.cs
+++ b/src/GxMcp.Worker/Services/BuildService.cs
@@ -15,6 +15,7 @@ using Artech.Architecture.Common.Services;
 using Artech.Udm.Framework;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Security;
 
 namespace GxMcp.Worker.Services
 {
@@ -126,14 +127,17 @@ namespace GxMcp.Worker.Services
                 if (string.IsNullOrEmpty(kbPath)) return "{\"error\": \"KB Path not found in Environment (GX_KB_PATH)\"}";
 
                 string tempFile = Path.Combine(Path.GetTempPath(), "GxBuild_" + Guid.NewGuid().ToString().Substring(0,8) + ".msbuild");
+                string importPath = SecurityElement.Escape(Path.Combine(_gxDir, "Genexus.Tasks.targets"));
+                string kbPathEsc = SecurityElement.Escape(kbPath);
+                string targetEsc = SecurityElement.Escape(target ?? string.Empty);
                 var sb = new StringBuilder();
                 sb.AppendLine("<Project DefaultTargets=\"Execute\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">");
-                sb.AppendLine("  <Import Project=\"" + Path.Combine(_gxDir, "Genexus.Tasks.targets") + "\" />");
+                sb.AppendLine("  <Import Project=\"" + importPath + "\" />");
                 sb.AppendLine("  <Target Name=\"Execute\">");
-                sb.AppendLine("    <OpenKnowledgeBase Directory=\"" + kbPath + "\" />");
-                
+                sb.AppendLine("    <OpenKnowledgeBase Directory=\"" + kbPathEsc + "\" />");
+
                 if (action.Equals("Build", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(target))
-                    sb.AppendLine("    <BuildOne BuildCalled=\"false\" ObjectName=\"" + target + "\" ForceRebuild=\"false\" />");
+                    sb.AppendLine("    <BuildOne BuildCalled=\"false\" ObjectName=\"" + targetEsc + "\" ForceRebuild=\"false\" />");
                 else if (action.Equals("RebuildAll", StringComparison.OrdinalIgnoreCase))
                     sb.AppendLine("    <RebuildAll />");
                 else if (action.Equals("Reorg", StringComparison.OrdinalIgnoreCase))

--- a/src/GxMcp.Worker/Services/RefactorService.cs
+++ b/src/GxMcp.Worker/Services/RefactorService.cs
@@ -147,7 +147,9 @@ namespace GxMcp.Worker.Services
 
             var index = _indexCacheService.GetIndex();
             var affectedObjects = new List<string>();
-            if (index != null && index.Objects.TryGetValue(oldName, out var entry)) if (entry.CalledBy != null) affectedObjects.AddRange(entry.CalledBy);
+            // index.Objects is keyed as "Type:Name" via GetEntryStorageKey, not bare Name.
+            if (index != null && index.Objects.TryGetValue("Attribute:" + oldName, out var entry) && entry.CalledBy != null)
+                affectedObjects.AddRange(entry.CalledBy);
 
             string pattern = @"(?i)\b" + System.Text.RegularExpressions.Regex.Escape(oldName) + @"\b";
             int updatedCount = 0;


### PR DESCRIPTION
## Summary
Two unrelated but low-risk worker fixes surfaced by an MCP health audit.

### 1. BuildService.BuildWithMSBuild — XML attribute injection
`target` (tool-supplied object name), `kbPath`, and the targets import path were concatenated directly into the generated `.msbuild` XML. A double quote or `>` in the object name could break out of the `ObjectName` attribute and inject arbitrary tasks that MSBuild would then execute under the worker process. All three values now flow through `SecurityElement.Escape`.

### 2. RefactorService.RenameAttribute — broken CalledBy lookup
`index.Objects.TryGetValue(oldName, ...)` never matched because `index.Objects` is keyed as `Type:Name` (`GetEntryStorageKey`). `affectedObjects` was always empty, so the regex source rewrite across calling objects was a silent no-op. Using `"Attribute:" + oldName` repairs the lookup so the rename actually propagates.

## Test plan
- [x] `dotnet build` clean on `GxMcp.Worker`.
- [ ] Trigger `genexus_build` with `action=Build` and an object name containing `"` / `<` / `>`: workflow should run cleanly without injecting extra tasks.
- [ ] Run `genexus_refactor rename_attribute` and verify calling procedures have their source updated (previously silent no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)