### PR TITLE
chore(release): v1.3.1 - update notification system

### DIFF
--- a/cli/commands/axi.js
+++ b/cli/commands/axi.js
@@ -871,6 +871,10 @@ function commandHelpMap() {
             usage: 'genexus-mcp llm help [--full] [--fields f1,f2] [--format toon|json|text]',
             examples: ['genexus-mcp llm help --format json', 'genexus-mcp llm help --full --format json']
         },
+        update: {
+            usage: 'genexus-mcp update [--format toon|json|text]',
+            examples: ['genexus-mcp update', 'genexus-mcp update --format json']
+        },
         layout: {
             usage: 'genexus-mcp layout status [--title "GeneXus"] [--format ...] OR genexus-mcp layout run --action <focus|activate-layout|activate-tab|send-keys|type-text|click> [--tab "Layout"] [--keys "..."] [--text "..."] [--x N --y N] [--title "..."] [--format ...] OR genexus-mcp layout inspect [--tab "Layout"] [--limit N] [--full] [--title "..."] [--format ...]',
             examples: ['genexus-mcp layout status --format json', 'genexus-mcp layout run --action activate-tab --tab "Layout" --format json', 'genexus-mcp layout inspect --tab Layout --format json']
@@ -935,7 +939,7 @@ async function handleHelp(targetCommand, ctx) {
                 bin: binPath,
                 command: 'genexus-mcp',
                 description: 'GeneXus MCP launcher and AXI-oriented utility CLI',
-                commands: ['home', 'axi home', 'status', 'doctor', 'tools list', 'config show', 'layout status', 'layout run', 'layout inspect', 'init', 'llm help', 'help'],
+                commands: ['home', 'axi home', 'status', 'doctor', 'tools list', 'config show', 'layout status', 'layout run', 'layout inspect', 'init', 'llm help', 'update', 'help'],
                 defaults: { format: 'toon', limit: 100 }
             },
             help: [

--- a/cli/index.js
+++ b/cli/index.js
@@ -22,6 +22,7 @@ const {
     usageEnvelope,
     commandHelpMap
 } = require('./commands/axi');
+const { startBackgroundUpdateCheck, handleUpdate } = require('./lib/update-check');
 
 const EXIT_CODES = {
     OK: 0,
@@ -43,7 +44,7 @@ const GLOBAL_DEFAULTS = {
     help: false
 };
 
-const KNOWN_COMMANDS = new Set(['status', 'doctor', 'tools', 'config', 'init', 'setup', 'help', 'home', 'axi', 'llm', 'layout']);
+const KNOWN_COMMANDS = new Set(['status', 'doctor', 'tools', 'config', 'init', 'setup', 'help', 'home', 'axi', 'llm', 'layout', 'update']);
 
 function parseArgs(argv) {
     const result = {
@@ -332,11 +333,16 @@ function resolveMetaCommand(parsed, targetHelp) {
         if (parsed.subcommand === 'inspect') return 'layout.inspect';
         return 'layout.status';
     }
+    if (parsed.command === 'update') return 'update';
     return parsed.command || 'unknown';
 }
 
 async function main(argv) {
     const parsed = parseArgs(argv);
+
+    if (parsed.command !== 'update') {
+        startBackgroundUpdateCheck({ quiet: parsed.options.quiet });
+    }
 
     if (!parsed.command) {
         return launchGateway(argv, parsed.options);
@@ -437,6 +443,9 @@ async function main(argv) {
             break;
         case 'init':
             result = await handleInit(parsed.options, ctx);
+            break;
+        case 'update':
+            result = await handleUpdate(parsed.options, ctx);
             break;
         default:
             writeStructured(

--- a/cli/lib/update-check.js
+++ b/cli/lib/update-check.js
@@ -1,0 +1,214 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const https = require('https');
+
+const REPO = 'lennix1337/Genexus18MCP';
+const NPM_PACKAGE = 'genexus-mcp';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 2000;
+
+function getPackageVersion() {
+    try {
+        const pkg = require('../../package.json');
+        return typeof pkg.version === 'string' ? pkg.version : null;
+    } catch {
+        return null;
+    }
+}
+
+function getCacheFile() {
+    return path.join(os.homedir(), '.genexus-mcp', 'update-check.json');
+}
+
+function readCache() {
+    try {
+        const raw = fs.readFileSync(getCacheFile(), 'utf8');
+        const data = JSON.parse(raw);
+        if (data && typeof data === 'object') return data;
+    } catch {
+    }
+    return null;
+}
+
+function writeCache(data) {
+    try {
+        const file = getCacheFile();
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, JSON.stringify(data), 'utf8');
+    } catch {
+    }
+}
+
+function stripV(v) {
+    return typeof v === 'string' ? v.replace(/^v/i, '').trim() : '';
+}
+
+function parseSemver(v) {
+    const s = stripV(v);
+    const m = /^(\d+)\.(\d+)\.(\d+)/.exec(s);
+    if (!m) return null;
+    return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compareSemver(a, b) {
+    const pa = parseSemver(a);
+    const pb = parseSemver(b);
+    if (!pa || !pb) return 0;
+    for (let i = 0; i < 3; i += 1) {
+        if (pa[i] > pb[i]) return 1;
+        if (pa[i] < pb[i]) return -1;
+    }
+    return 0;
+}
+
+function fetchLatestRelease() {
+    return new Promise((resolve) => {
+        const options = {
+            hostname: 'api.github.com',
+            path: `/repos/${REPO}/releases/latest`,
+            method: 'GET',
+            headers: {
+                'User-Agent': `${NPM_PACKAGE}-cli`,
+                'Accept': 'application/vnd.github+json'
+            }
+        };
+
+        const req = https.request(options, (res) => {
+            if (res.statusCode !== 200) {
+                res.resume();
+                resolve(null);
+                return;
+            }
+            let body = '';
+            res.setEncoding('utf8');
+            res.on('data', (chunk) => { body += chunk; });
+            res.on('end', () => {
+                try {
+                    const json = JSON.parse(body);
+                    const tag = stripV(json.tag_name || '');
+                    const url = typeof json.html_url === 'string' ? json.html_url : null;
+                    if (!tag) { resolve(null); return; }
+                    resolve({ latestVersion: tag, releaseUrl: url });
+                } catch {
+                    resolve(null);
+                }
+            });
+        });
+
+        req.on('error', () => resolve(null));
+        req.setTimeout(FETCH_TIMEOUT_MS, () => {
+            req.destroy();
+            resolve(null);
+        });
+
+        req.end();
+        if (typeof req.unref === 'function') req.unref();
+    });
+}
+
+function formatBanner(current, latest, releaseUrl) {
+    const lines = [
+        `[genexus-mcp] update available: v${current} -> v${latest}`,
+        `[genexus-mcp] run: npm install -g ${NPM_PACKAGE}@latest`
+    ];
+    if (releaseUrl) lines.push(`[genexus-mcp] release: ${releaseUrl}`);
+    return lines.join('\n') + '\n';
+}
+
+function isDisabled(opts) {
+    if (process.env.GENEXUS_MCP_NO_UPDATE_CHECK === '1') return true;
+    if (opts && opts.quiet) return true;
+    if (!process.stderr || !process.stderr.isTTY) return true;
+    return false;
+}
+
+function maybePrintCachedBanner(opts) {
+    const current = getPackageVersion();
+    if (!current) return;
+    const cache = readCache();
+    if (!cache || !cache.latestVersion) return;
+    if (compareSemver(cache.latestVersion, current) > 0) {
+        try {
+            process.stderr.write(formatBanner(current, cache.latestVersion, cache.releaseUrl || null));
+        } catch {
+        }
+    }
+}
+
+function scheduleBackgroundFetch() {
+    const cache = readCache();
+    const now = Date.now();
+    if (cache && typeof cache.checkedAt === 'number' && (now - cache.checkedAt) < CACHE_TTL_MS) {
+        return;
+    }
+
+    fetchLatestRelease().then((result) => {
+        if (!result) return;
+        writeCache({
+            checkedAt: Date.now(),
+            latestVersion: result.latestVersion,
+            releaseUrl: result.releaseUrl
+        });
+    }).catch(() => {});
+}
+
+function startBackgroundUpdateCheck(opts) {
+    if (isDisabled(opts)) return;
+    maybePrintCachedBanner(opts);
+    scheduleBackgroundFetch();
+}
+
+async function handleUpdate(_options, ctx) {
+    const current = getPackageVersion();
+    const result = await fetchLatestRelease();
+
+    if (!result) {
+        return {
+            exitCode: ctx.EXIT_CODES.OK,
+            envelope: {
+                ok: {
+                    current,
+                    latest: null,
+                    updateAvailable: false,
+                    fetched: false
+                },
+                help: ['Could not reach GitHub releases API. Check connectivity or retry later.']
+            }
+        };
+    }
+
+    writeCache({
+        checkedAt: Date.now(),
+        latestVersion: result.latestVersion,
+        releaseUrl: result.releaseUrl
+    });
+
+    const updateAvailable = compareSemver(result.latestVersion, current || '0.0.0') > 0;
+    const help = updateAvailable
+        ? [`Run: npm install -g ${NPM_PACKAGE}@latest`, result.releaseUrl ? `Release: ${result.releaseUrl}` : null].filter(Boolean)
+        : ['Already on latest version.'];
+
+    return {
+        exitCode: ctx.EXIT_CODES.OK,
+        envelope: {
+            ok: {
+                current,
+                latest: result.latestVersion,
+                releaseUrl: result.releaseUrl,
+                updateAvailable,
+                installCommand: `npm install -g ${NPM_PACKAGE}@latest`,
+                fetched: true
+            },
+            help
+        }
+    };
+}
+
+module.exports = {
+    startBackgroundUpdateCheck,
+    handleUpdate,
+    compareSemver,
+    parseSemver,
+    getPackageVersion
+};

--- a/cli/run.test.js
+++ b/cli/run.test.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const os = require('node:os');
 const fs = require('node:fs');
 const { renderOutput } = require('./lib/output');
+const { compareSemver } = require('./lib/update-check');
 
 const cliPath = path.join(__dirname, 'run.js');
 
@@ -302,6 +303,24 @@ test('quiet flag suppresses launcher stderr noise', () => {
 
     assert.equal(result.status, 1);
     assert.equal(result.stderr.trim(), '');
+});
+
+test('update --help returns usage entry', () => {
+    const result = runCli(['update', '--help', '--format', 'json']);
+    assert.equal(result.status, 0);
+
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.meta.command, 'help');
+    assert.equal(parsed.ok.command, 'update');
+    assert.ok(parsed.ok.usage.includes('genexus-mcp update'));
+});
+
+test('compareSemver detects newer, older, equal versions', () => {
+    assert.equal(compareSemver('1.3.1', '1.3.0'), 1);
+    assert.equal(compareSemver('v1.4.0', '1.3.9'), 1);
+    assert.equal(compareSemver('1.3.0', '1.3.0'), 0);
+    assert.equal(compareSemver('1.2.9', '1.3.0'), -1);
+    assert.equal(compareSemver('garbage', '1.0.0'), 0);
 });
 
 test('gateway passthrough remains intact when no AXI subcommand is used', () => {

--- a/install.ps1
+++ b/install.ps1
@@ -409,14 +409,29 @@ if (-not $SkipExtensionInstall) {
         if ($LASTEXITCODE -ne 0) {
             $vsceLog = Join-Path $extensionDir "vsce-package.log"
             Write-Error "vsce package failed. Checking for common issues..."
-            if (-not (Test-Path (Join-Path $extensionDir "LICENSE.txt"))) {
-                Write-Warn "LICENSE.txt is missing in $extensionDir. Copying from root..."
-                Copy-Item (Join-Path $root "LICENSE.txt") (Join-Path $extensionDir "LICENSE.txt")
-                & $npxCommand --yes @vscode/vsce package --out nexus-ide.vsix
+            $extensionLicensePath = Join-Path $extensionDir "LICENSE.txt"
+            if (-not (Test-Path $extensionLicensePath)) {
+                $licenseCandidates = @("LICENSE.txt", "LICENSE.md", "LICENSE")
+                $sourceLicensePath = $null
+                foreach ($candidate in $licenseCandidates) {
+                    $candidatePath = Join-Path $root $candidate
+                    if (Test-Path $candidatePath) {
+                        $sourceLicensePath = $candidatePath
+                        break
+                    }
+                }
+
+                if ($sourceLicensePath) {
+                    Write-Warn "LICENSE.txt is missing in $extensionDir. Copying from $sourceLicensePath..."
+                    Copy-Item $sourceLicensePath $extensionLicensePath -Force
+                    & $npxCommand --yes @vscode/vsce package --out nexus-ide.vsix
+                } else {
+                    Write-Warn "No license file found at repository root (LICENSE, LICENSE.md, LICENSE.txt)."
+                }
             }
-            
+
             if ($LASTEXITCODE -ne 0) {
-                throw "vsce package failed again. Please check if LICENSE.txt is being ignored by Git or if there are other issues in package.json."
+                throw "vsce package failed again. Please check license include patterns and package.json."
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genexus-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A high-performance Model Context Protocol (MCP) server for GeneXus 18",
   "scripts": {
     "test": "node --test cli/run.test.js",

--- a/src/nexus-ide/package.json
+++ b/src/nexus-ide/package.json
@@ -39,7 +39,7 @@
     "syntaxes",
     "themes",
     "README.md",
-    "LICENSE",
+    "LICENSE.txt",
     "genexus-icons.json",
     "language-configuration.json"
   ],


### PR DESCRIPTION
## Summary
- New `cli/lib/update-check.js` checks GitHub releases, prints stderr banner with `npm install -g genexus-mcp@latest` when newer version exists
- TTY-only auto-check, 24h cache, 2s timeout, unref'd fetch — does not interfere with MCP stdio or AXI CLI stdout
- New `genexus-mcp update` subcommand for explicit on-demand check
- Bump to v1.3.1
- Bundled fix: `install.ps1` LICENSE filename resolution for vsce packaging

## Test plan
- [x] `node --test cli/run.test.js` — 23/23 pass
- [x] `genexus-mcp update --format json` — live GitHub call, returns envelope
- [x] Existing `stderr === ''` assertions intact (no-TTY gate)
- [ ] Verify auto-banner displays in interactive shell after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)