### PR TITLE
docs: correct folder/module placement claims overturned in v2.35.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ If the build fails with `MSB3027` / `MSB3021` citing `GxMcp.Gateway.exe` or `GxM
 ### Test
 
 ```powershell
-dotnet test src\GxMcp.Worker.Tests\GxMcp.Worker.Tests.csproj      # net48; ~570 tests
-dotnet test src\GxMcp.Gateway.Tests\GxMcp.Gateway.Tests.csproj    # net8.0; ~310 tests
+dotnet test src\GxMcp.Worker.Tests\GxMcp.Worker.Tests.csproj      # net48;  ~1,790 tests
+dotnet test src\GxMcp.Gateway.Tests\GxMcp.Gateway.Tests.csproj    # net8.0;   ~760 tests
 dotnet test Genexus18MCP.sln                                     # both
 npm test                                                          # cli tests only (node --test)
 
@@ -238,14 +238,38 @@ Verb { <route> => <Object>; <route2> => <Object2>; }
   (set the Procedure's `REST=True` / `Expose as ...`) reached at `<app>/rest/<ProcName>`,
   rather than trying to mix verbs in one API object.
 
-### Folder / module placement is read-only via the SDK
+### Folder / module placement (SDK-backed since v2.35.0)
 
-Moving an object into a folder or module is **not** supported through the tools:
-`KBObject`'s `Parent` / `ParentKey` / `Module` setters are no-op stubs at the IL
-level in the GeneXus 18 SDK. `genexus_properties action=set propertyName=Folder`
-now fails with `FolderMoveNotSupported` instead of silently reporting success.
-Create folders/modules with `genexus_create type=Folder|Module`, but place objects
-into them from the GeneXus IDE (KB Explorer drag-and-drop / right-click Move).
+Objects **can** be placed into a Folder or Module through the tools — the same
+operation as KB Explorer drag-and-drop / right-click → Move in the IDE.
+
+- **Move an existing object:** `genexus_properties action=move name=<obj>
+  destination=<Folder or Module>`. The container kind is auto-detected; pass
+  `destKind=Folder|Module` only to disambiguate a shared name. `dryRun=true`
+  previews `from` / `to` without writing.
+- **Write-back is verified.** The parent is re-read after the save, so a write
+  the SDK silently drops returns `MoveNotPersisted` rather than a false success.
+- **Create directly in a container:** `genexus_create … folder=<name>` or
+  `module=<name>` creates the object in Root Module and then moves it, reporting
+  the outcome under `placement`.
+- **`action=set` on a placement property is routed, not rejected.**
+  `propertyName=Folder|FolderId|FolderGuid|Module|ModuleId|Parent|ParentKey|ParentId`
+  is recognised as a reparent (`PropertyService.IsObjectPlacementProperty`) and
+  dispatched to `ObjectService.MoveObject` instead of a scalar property write.
+- **`list` / `inspect` re-file immediately** — `IndexCacheService.InvalidateHierarchy`
+  drops the per-Guid hierarchy cache and the old parent's `ChildrenByParent` slot
+  before the index entry is updated.
+
+Create the containers themselves with `genexus_create type=Folder|Module`.
+
+> **Why the SDK looks like it can't do this.** `KBObject`'s `Parent` / `ParentKey` /
+> `Module` setters *do* read as empty stubs at the IL level — but only in the
+> facade/reference assembly. Decompiling that assembly is what produced the
+> earlier "placement is unsupported" verdict. The runtime persist goes through
+> `Artech.Udm.Framework.EntityManager.SaveWithParent` (see
+> `src/GxMcp.Worker/Helpers/ObjectMover.cs`, with `UpdateParent` and `KBObject.Save`
+> as fallbacks). Don't re-derive the old conclusion from a reference-assembly
+> decompile.
 
 ### Control-bound events must be written AFTER the layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Agent instructions no longer claim that folder/module placement is impossible.** `AGENTS.md` — loaded as context in every agent session, and the shared convention file for Claude Code, Cursor, Codex and Aider — still described object placement as an SDK wall and told agents to move objects from the GeneXus IDE by hand. Placement has worked since v2.35.0, so agents reading that section were skipping `genexus_properties action=move` and `genexus_create folder=`/`module=` entirely. The section now documents the move, the `MoveNotPersisted` write-back check, and the fact that `action=set propertyName=Folder` is routed to the move rather than rejected. Server behavior is unchanged — only the instructions were wrong.
+
+### Internal
+
+- The rewritten `AGENTS.md` section keeps a short *why this was believed* note: the `Parent`/`ParentKey`/`Module` setters genuinely read as empty stubs in the facade/reference assembly, which is what produced the original verdict; the runtime persist goes through `EntityManager.SaveWithParent` (`ObjectMover`). Without that note the wrong conclusion is re-derivable from a decompile.
+- Struck the matching "confirmed WALL" line in `docs/sdk_uncovered_endpoints_2026-07-20.md` with a dated pointer to v2.35.0, leaving the rest of that dated snapshot intact.
+- `PropertyService._placementProps` and the `McpRouterTests` issue-#50 comment described the pre-v2.35.0 rejection paths; both now describe the routing that replaced them.
+- Corrected the test counts in `AGENTS.md` (they understated both suites by roughly 2.4x) and the tool count in `README.md` (46 → 47, adding the missing `genexus_wwp` bullet to Tool Surface).
+
 ## v2.38.0 — 2026-08-01
 
 The release improves safe GeneXus authoring, persistence verification, inline specification feedback, source-search performance, and modern MCP interoperability.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In practice: you point the MCP at your KB, then ask your AI assistant things lik
 
 ## What you can do with it
 
-A quick map of what the agent can do against your real KB through the **46 tools** (details in [Tool Surface](#tool-surface)):
+A quick map of what the agent can do against your real KB through the **47 tools** (details in [Tool Surface](#tool-surface)):
 
 | Area | What the agent can do |
 |---|---|
@@ -234,7 +234,7 @@ Still stuck? [Open an issue](https://github.com/lennix1337/Genexus18MCP/issues) 
 
 ## Tool Surface
 
-The worker exposes **46 tools** to the MCP router, grouped by capability below. Most are umbrellas with an `action` (e.g. `genexus_db action=sql_ddl`); the detailed schemas live in [`src/GxMcp.Gateway/tool_definitions.json`](src/GxMcp.Gateway/tool_definitions.json).
+The worker exposes **47 tools** to the MCP router, grouped by capability below. Most are umbrellas with an `action` (e.g. `genexus_db action=sql_ddl`); the detailed schemas live in [`src/GxMcp.Gateway/tool_definitions.json`](src/GxMcp.Gateway/tool_definitions.json).
 
 **Orientation & health**
 - `genexus_whoami` — KB context, version, worker/index/database health, self-update check, next-step hints
@@ -267,6 +267,7 @@ The worker exposes **46 tools** to the MCP router, grouped by capability below. 
 **Refactor, patterns & compare**
 - `genexus_refactor` — rename, extract procedure, WWP condition set
 - `genexus_apply_pattern` — apply a GeneXus pattern (WorkWith, WorkWithPlus, …); `mode=actions` manages typed WorkWithPlus grid actions and Action Groups
+- `genexus_wwp` — WorkWithPlus Action Group / grid-action editing: `list`, `add_action`, `update_action`, `move_action`, `remove_action`
 - `genexus_compare` — IDE "Compare Objects" parity (`IComparerService`)
 - `genexus_merge` — 2- or 3-way object merge (`IMergeService`)
 

--- a/docs/sdk_uncovered_endpoints_2026-07-20.md
+++ b/docs/sdk_uncovered_endpoints_2026-07-20.md
@@ -93,7 +93,10 @@ objects & parts CRUD (`genexus_create/read/edit/delete_object`), structure/varia
 (`genexus_structure`, `genexus_variable`), layout/WebForm (`genexus_layout`, `genexus_edit_form`),
 patterns (`genexus_apply_pattern`), refactor (`genexus_refactor`). Known residual gaps on this axis
 are already tracked in `docs/sdk_coverage_gap_matrix.md`:
-**Move object to folder/module** (SDK setters are no-op stubs — confirmed WALL, see AGENTS.md),
+~~**Move object to folder/module** (SDK setters are no-op stubs — confirmed WALL, see AGENTS.md)~~
+— **superseded 2026-07-24 (v2.35.0):** shipped as `genexus_properties action=move`, persisted via
+`EntityManager.SaveWithParent`. The "no-op stubs" reading came from a facade/reference assembly;
+see CHANGELOG v2.35.0 and `src/GxMcp.Worker/Helpers/ObjectMover.cs`.
 **WWP settings/components persist** (⛔ blocked, `project_wwp_settings_components_persist_blocked`),
 and the **full 9-hook pattern build sequence** (only `UpdateParentObject` wired).
 

--- a/src/GxMcp.Gateway.Tests/McpRouterTests.cs
+++ b/src/GxMcp.Gateway.Tests/McpRouterTests.cs
@@ -365,8 +365,9 @@ namespace GxMcp.Gateway.Tests
         }
 
         // issue #50: a requested folder/module destination is forwarded to the worker (as
-        // folder/destModule/parentPath) so it can reject with FolderPlacementUnsupported instead
-        // of silently creating in Root Module. `module` is remapped to destModule to avoid
+        // folder/destModule/parentPath) so the object actually lands there — since v2.35.0 the
+        // worker creates in Root Module and then moves, reporting the outcome under `placement`,
+        // instead of the earlier up-front rejection. `module` is remapped to destModule to avoid
         // colliding with the routing `module=Object` field.
         [Fact]
         public void ConvertToolCall_CreateObject_ForwardsFolderDestination()

--- a/src/GxMcp.Worker/Services/PropertyService.cs
+++ b/src/GxMcp.Worker/Services/PropertyService.cs
@@ -321,9 +321,10 @@ namespace GxMcp.Worker.Services
             { PropertyName = propName; }
         }
 
-        // Object-level placement "properties" that the SDK exposes but cannot persist
-        // (the Parent/ParentKey/Module setters are IL no-ops). Setting any of these on an
-        // object silently does nothing, so we reject the write up front.
+        // Object-level "properties" that actually mean "reparent this object". They are not
+        // scalar property writes, so a request naming one is routed to ObjectService.MoveObject
+        // (which persists via the Udm EntityManager and re-reads to confirm) rather than being
+        // pushed through SetPropertyValue. See ObjectMover for why the direct setters look inert.
         private static readonly HashSet<string> _placementProps = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Folder", "FolderId", "FolderGuid", "Module", "ModuleId", "Parent", "ParentKey", "ParentId"


### PR DESCRIPTION
Fixes #65.

Documentation-only, plus two stale code comments. **No behavior change** — nothing in the request path was touched.

## Why

`AGENTS.md` described folder/module placement as a hard SDK wall and told agents to move objects from the GeneXus IDE by hand. That was true until **v2.35.0** (commit `ad9b275`, 2026-07-24) implemented it. That commit touched 11 files; `AGENTS.md` wasn't one of them.

Since `AGENTS.md` is loaded as context in every agent session, the practical cost was that agents read an authoritative "not supported" and never reached for `genexus_properties action=move` or `genexus_create folder=`/`module=`.

## What changed

| File | Change |
|---|---|
| `AGENTS.md` | Section rewritten as **"Folder / module placement (SDK-backed since v2.35.0)"** — documents `action=move` (`destKind`, `dryRun`), the `MoveNotPersisted` write-back check, `genexus_create folder=`/`module=` reporting under `placement`, the routing of `action=set` on placement properties, and the `InvalidateHierarchy` re-file. The string `FolderMoveNotSupported` no longer appears in the file. |
| `AGENTS.md` | Test counts `~570`/`~310` → `~1,790`/`~760` (measured, see below). |
| `docs/sdk_uncovered_endpoints_2026-07-20.md` | The "confirmed WALL" line struck through with a dated pointer to v2.35.0. The rest of the dated snapshot is untouched — it stays a historical probe record. |
| `src/GxMcp.Worker/Services/PropertyService.cs` | The comment above `_placementProps` said the SDK "cannot persist" these and that the write is rejected up front. It now describes the routing to `ObjectService.MoveObject` that replaced the rejection. |
| `src/GxMcp.Gateway.Tests/McpRouterTests.cs` | Same class of drift, found while grepping: the issue-#50 comment said the destination is forwarded "so it can reject with `FolderPlacementUnsupported`". Since v2.35.0 the worker creates in Root Module and moves. The assertions were already correct; only the comment was stale. |
| `README.md` | `46 tools` → `47` (two places), plus the missing `genexus_wwp` bullet under Refactor, patterns & compare. |
| `CHANGELOG.md` | `## Unreleased` entry: one user-facing `### Fixed` bullet, the rest under `### Internal`. |

### The one deliberate non-deletion

The rewritten section keeps a short **why this was believed** note: the `Parent` / `ParentKey` / `Module` setters *do* read as empty stubs — in the facade/reference assembly — and the runtime persist goes through `EntityManager.SaveWithParent` (`ObjectMover`). Deleting the wrong claim without recording why it was plausible invites the next agent to decompile that same assembly and re-add the warning.

## Tested against

- **Agent/client:** Claude Code
- **MCP server:** v2.38.0 (npm `genexus-mcp`), Streamable HTTP on loopback
- **GeneXus:** 18.0.13.186738
- **KB:** private corporate KB, ~14.8k objects, index Ready
- **Object types exercised:** Procedure, Folder, Module

A read-only `dryRun` is enough to show the documented wall isn't there:

```jsonc
// genexus_properties action=move name=<SomeProcedure>
//                    destination=<TargetFolder> destKind=Folder dryRun=true
{
  "status": "ok",
  "code": "DryRun",
  "target": "<SomeProcedure>",
  "result": {
    "move": "<SomeProcedure>",
    "from": "<SourceFolder>",
    "to": "<TargetFolder>",
    "containerType": "Folder",
    "hint": "Re-run without dryRun to persist the move."
  }
}
```

It resolved the object's current container, the destination and the container kind. No `FolderMoveNotSupported`. (Object names redacted — private KB. The envelope is otherwise verbatim. I deliberately stopped at `dryRun`: it's a live production ERP KB, and the dry run already falsifies the claim without a write.)

## Test runs

Both suites, on this branch:

```
GxMcp.Worker.Tests    net48    Passed 1782, Skipped 4, Failed 0   Total 1786
GxMcp.Gateway.Tests   net8.0   Passed  752, Skipped 7, Failed 1   Total  760
```

Those totals are where the corrected `~1,790` / `~760` figures come from. (Counting `[Fact]`/`[Theory]` attributes gives 1,423 / 664 — the gap is `[InlineData]` expansion, which is why I used an actual run rather than a source count.)

### The one Gateway failure is pre-existing, not from this PR

`OperationTrackerTests.CleanupExpired_DoesNotDropMappingForReusedRequestId` fails in the full suite and passes in isolation. I checked it against a clean `main` worktree before opening this:

| Tree | Result |
|---|---|
| `main` @ `572fb5e` (v2.38.0), full suite | Failed 1, Passed 752, Skipped 7, **Total 760** |
| this branch, full suite | Failed 1, Passed 752, Skipped 7, **Total 760** |
| this branch, `--filter` on that one test | **Passed**, 65 ms |

Identical, and this PR only adds a comment to `McpRouterTests.cs` on the Gateway side — nothing that could reach `OperationTracker`.

Worth noting it reproduced on **2 of 2** full-suite runs, so it looks order- or parallelism-dependent rather than intermittently timing-flaky. `AGENTS.md` lists the known flaky tests but they're both Worker-side (`EdgeCaseRegressionTests.Dispatcher_PatchApply_ValidateOnly_MapsToDryRun_ViaConvention`, `PatternApplyServiceTests.*`), so this one isn't recorded anywhere.

Out of scope here — happy to open a separate issue if it isn't already on your radar.

## Grep check

```
$ rg -n "FolderMoveNotSupported|FolderPlacementUnsupported|no-op stub" -g '!publish/**'
```

Remaining hits are all intentional: shipped `CHANGELOG.md` history (not rewritten), the struck-through line and its explanation in the dated snapshot, the `ObjectService.cs:1470` "replaces the old …" comment, and the `ToolSchemaSizeTests.cs` budget-bump log.
