### PR TITLE
feat: add out-of-band MCP recovery client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added `scripts/mcp_recover.ps1`, an out-of-band Streamable HTTP client for
+  continuing diagnostics when a client-owned STDIO transport has closed. It
+  initializes a fresh session, discovers the current catalog, and blocks tools
+  not marked read-only unless `-AllowWrite` is passed explicitly.
+
 ## v2.39.3 — 2026-08-09
 
 ### Fixed

--- a/docs/mcp_debugging_guide.md
+++ b/docs/mcp_debugging_guide.md
@@ -37,6 +37,25 @@ When launching the gateway as a stdio MCP server:
 - logs belong on stderr
 - the process must stay idle without printing banner text
 
+### Recover after a closed client transport
+
+If a client-owned STDIO process exits, the client may keep reporting
+`Transport closed` even though the Gateway HTTP endpoint is healthy. A dead
+STDIO stream cannot carry a command that repairs itself. Keep the existing
+conversation/history and use the out-of-band HTTP client:
+
+```powershell
+.\scripts\mcp_recover.ps1 `
+  -BaseUrl http://127.0.0.1:5000/mcp `
+  -Tool genexus_whoami
+```
+
+The script creates a fresh MCP session, discovers the live tool catalog, and
+blocks every tool not explicitly annotated read-only. After reviewing a
+mutating request, pass `-AllowWrite` to opt in. The Gateway must already be
+running at `BaseUrl`; process supervision remains the deployment's
+responsibility.
+
 ## Common failure modes
 
 ### Invalid JSON-RPC id handling

--- a/scripts/mcp_recover.ps1
+++ b/scripts/mcp_recover.ps1
@@ -1,0 +1,117 @@
+[CmdletBinding()]
+param(
+    [string]$BaseUrl = 'http://127.0.0.1:5000/mcp',
+    [string]$Tool = 'genexus_whoami',
+    [string]$ArgumentsJson = '{}',
+    [switch]$AllowWrite,
+    [switch]$ListTools,
+    [ValidateRange(1, 3600)]
+    [int]$TimeoutSec = 900
+)
+
+$ErrorActionPreference = 'Stop'
+$protocolVersion = '2025-11-25'
+
+try {
+    $arguments = $ArgumentsJson | ConvertFrom-Json -AsHashtable -Depth 50
+} catch {
+    throw "ArgumentsJson is invalid: $($_.Exception.Message)"
+}
+if ($null -eq $arguments) { $arguments = @{} }
+if ($arguments -isnot [System.Collections.IDictionary]) {
+    throw 'ArgumentsJson must be a JSON object, for example: {"limit":10}'
+}
+
+function Invoke-McpRequest {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Method,
+        [hashtable]$Params,
+        [string]$SessionId = ''
+    )
+
+    $headers = @{
+        'MCP-Protocol-Version' = $protocolVersion
+        'Accept' = 'application/json, text/event-stream'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($SessionId)) {
+        $headers['MCP-Session-Id'] = $SessionId
+    }
+
+    $request = @{
+        jsonrpc = '2.0'
+        id = [guid]::NewGuid().ToString('N')
+        method = $Method
+    }
+    if ($null -ne $Params) { $request['params'] = $Params }
+
+    $response = Invoke-WebRequest `
+        -Uri $BaseUrl `
+        -Method Post `
+        -Headers $headers `
+        -ContentType 'application/json' `
+        -Body ($request | ConvertTo-Json -Depth 50 -Compress) `
+        -TimeoutSec $TimeoutSec `
+        -UseBasicParsing
+
+    [pscustomobject]@{
+        Payload = $response.Content | ConvertFrom-Json -Depth 100
+        SessionId = [string](@($response.Headers['MCP-Session-Id'])[0])
+    }
+}
+
+$initialized = Invoke-McpRequest -Method 'initialize' -Params @{
+    protocolVersion = $protocolVersion
+    capabilities = @{}
+    clientInfo = @{ name = 'genexus-mcp-recovery'; version = '1.0.0' }
+}
+$sessionId = $initialized.SessionId
+if ([string]::IsNullOrWhiteSpace($sessionId)) {
+    throw 'The initialize response did not include MCP-Session-Id.'
+}
+if ($initialized.Payload.error) {
+    throw ($initialized.Payload.error | ConvertTo-Json -Depth 20 -Compress)
+}
+
+$catalogResponse = Invoke-McpRequest -Method 'tools/list' -Params @{} -SessionId $sessionId
+if ($catalogResponse.Payload.error) {
+    throw ($catalogResponse.Payload.error | ConvertTo-Json -Depth 20 -Compress)
+}
+$catalog = @($catalogResponse.Payload.result.tools)
+
+if ($ListTools) {
+    $catalog |
+        Sort-Object name |
+        Select-Object name,
+            @{name='readOnly';expression={$_.annotations.readOnlyHint}},
+            @{name='destructive';expression={$_.annotations.destructiveHint}} |
+        Format-Table -AutoSize
+    return
+}
+
+$definition = $catalog | Where-Object name -eq $Tool | Select-Object -First 1
+if ($null -eq $definition) {
+    throw "Tool not found: $Tool. Use -ListTools to inspect the catalog."
+}
+
+$readOnly = $definition.annotations.readOnlyHint -eq $true
+if (-not $readOnly -and -not $AllowWrite) {
+    throw "Tool '$Tool' is not marked read-only. Review the request and pass -AllowWrite explicitly."
+}
+
+$callResponse = Invoke-McpRequest -Method 'tools/call' -Params @{
+    name = $Tool
+    arguments = $arguments
+} -SessionId $sessionId
+if ($callResponse.Payload.error) {
+    throw ($callResponse.Payload.error | ConvertTo-Json -Depth 50 -Compress)
+}
+
+foreach ($item in @($callResponse.Payload.result.content)) {
+    if ($item.type -eq 'text') {
+        Write-Output $item.text
+    } else {
+        Write-Output ($item | ConvertTo-Json -Depth 50 -Compress)
+    }
+}
+if ($callResponse.Payload.result.isError) { exit 1 }


### PR DESCRIPTION
## Summary
- add a standalone Streamable HTTP recovery client for cases where a client-owned STDIO transport has closed
- initialize a fresh MCP session and discover the live tool catalog before calling a tool
- block tools not annotated read-only unless the operator passes `-AllowWrite` explicitly
- document how to keep the existing conversation/history while using the out-of-band route

## Validation
- PowerShell parser: passed
- live `tools/list` against GeneXus MCP 2.39.3: passed
- live `genexus_whoami` against GeneXus 18 U16: passed
- mutating `genexus_edit` without `-AllowWrite`: blocked before tools/call
- no KB writes, builds, generation, reorganization, or deployment performed
