### PR TITLE
test(coverage): support non-default GeneXus SDK paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         shell: pwsh
         run: |
           ./scripts/coverage/collect.ps1 -OutputRoot "$env:RUNNER_TEMP\gx-coverage-artifacts"
-          ./scripts/coverage/assert-threshold.ps1 -CoverageRoot "$env:RUNNER_TEMP\gx-coverage-artifacts" -MinLineRatePercent 50
+          ./scripts/coverage/assert-threshold.ps1 -CoverageRoot "$env:RUNNER_TEMP\gx-coverage-artifacts" -MinLineRatePercent 60
 
       - name: Upload coverage artifacts
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,17 @@ $coverageRoot = Join-Path $env:TEMP 'gx-coverage-pr'
 cd src\nexus-ide; npm run lint
 ```
 
-`collect.ps1` skips the Worker half when GeneXus 18 isn't installed locally (it drops a `worker.skipped.txt` marker and `assert-threshold.ps1` enforces only the Gateway floor in that case) — so without a local GeneXus install you exercise the Gateway coverage gate only, same as a GitHub-hosted runner.
+`collect.ps1` resolves the GeneXus SDK from `-GxPath`, then `GX_PATH`, then the default installation directory. For a non-default installation, use either form:
+
+```pwsh
+$env:GX_PATH = 'C:\GeneXus\GeneXus18U16'
+.\scripts\coverage\collect.ps1 -OutputRoot $coverageRoot
+
+# Or keep the setting scoped to this invocation.
+.\scripts\coverage\collect.ps1 -OutputRoot $coverageRoot -GxPath 'C:\GeneXus\GeneXus18U16'
+```
+
+An explicitly configured path that does not contain `Artech.Architecture.Common.dll` fails immediately instead of silently skipping Worker coverage. When no path is configured and the default installation is absent, the script drops a `worker.skipped.txt` marker and `assert-threshold.ps1` enforces only the Gateway floor — the same behavior as a GitHub-hosted runner.
 
 If a tool schema or description changed, update and verify the discovery golden before running coverage:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,10 @@ If you only touched `cli/`, `npm test` is enough. If you touched the Gateway or 
 CI (`.github/workflows/ci.yml`) also runs steps not in the dev loop above, so a green local run can still hit CI-only failures. To reproduce them locally:
 
 ```pwsh
-# Coverage collection + threshold gate (50% line rate), exactly as CI runs it
+# Coverage collection + threshold gate (60% line rate), exactly as CI runs it
 $coverageRoot = Join-Path $env:TEMP 'gx-coverage-pr'
 .\scripts\coverage\collect.ps1 -OutputRoot $coverageRoot
-.\scripts\coverage\assert-threshold.ps1 -CoverageRoot $coverageRoot -MinLineRatePercent 50
+.\scripts\coverage\assert-threshold.ps1 -CoverageRoot $coverageRoot -MinLineRatePercent 60
 
 # LLM tool-contract smoke
 .\scripts\mcp_llm_contract_smoke.ps1
@@ -62,6 +62,8 @@ $env:GX_PATH = 'C:\GeneXus\GeneXus18U16'
 ```
 
 An explicitly configured path that does not contain `Artech.Architecture.Common.dll` fails immediately instead of silently skipping Worker coverage. When no path is configured and the default installation is absent, the script drops a `worker.skipped.txt` marker and `assert-threshold.ps1` enforces only the Gateway floor — the same behavior as a GitHub-hosted runner.
+
+Do not add coverage exclusions merely to satisfy the floor. Add tests that execute the affected contract, run the complete command above, and confirm that `Gateway line-rate` (and `Worker line-rate` when an SDK is configured) is at least 60% before pushing.
 
 If a tool schema or description changed, update and verify the discovery golden before running coverage:
 

--- a/scripts/coverage/assert-threshold.ps1
+++ b/scripts/coverage/assert-threshold.ps1
@@ -1,6 +1,6 @@
 param(
     [string]$CoverageRoot = "",
-    [double]$MinLineRatePercent = 50
+    [double]$MinLineRatePercent = 60
 )
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)

--- a/scripts/coverage/collect.ps1
+++ b/scripts/coverage/collect.ps1
@@ -1,8 +1,36 @@
 param(
-    [string]$OutputRoot = ""
+    [string]$OutputRoot = "",
+    [string]$GxPath = ""
 )
 
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$defaultGxPath = "C:\Program Files (x86)\GeneXus\GeneXus18"
+
+function Resolve-GxSdkPath {
+    $configuredPath = if (-not [string]::IsNullOrWhiteSpace($GxPath)) {
+        $GxPath
+    } elseif (-not [string]::IsNullOrWhiteSpace($env:GX_PATH)) {
+        $env:GX_PATH
+    } else {
+        ""
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($configuredPath)) {
+        $resolvedPath = [System.IO.Path]::GetFullPath($configuredPath.Trim().Trim('"'))
+        $sdkAssembly = Join-Path $resolvedPath "Artech.Architecture.Common.dll"
+        if (-not (Test-Path -LiteralPath $sdkAssembly -PathType Leaf)) {
+            throw "GeneXus SDK not found under configured GX_PATH '$resolvedPath'. Expected '$sdkAssembly'."
+        }
+        return $resolvedPath
+    }
+
+    $defaultAssembly = Join-Path $defaultGxPath "Artech.Architecture.Common.dll"
+    if (Test-Path -LiteralPath $defaultAssembly -PathType Leaf) {
+        return $defaultGxPath
+    }
+
+    return $null
+}
 
 if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
     if ($env:RUNNER_TEMP) {
@@ -20,14 +48,25 @@ function Invoke-CoverageTest {
         [Parameter(Mandatory = $true)][string]$ProjectPath,
         [Parameter(Mandatory = $true)][string]$Label,
         [Parameter(Mandatory = $true)][string]$BaseOutputPath,
-        [Parameter(Mandatory = $true)][string]$SettingsPath
+        [Parameter(Mandatory = $true)][string]$SettingsPath,
+        [string[]]$BuildProperties = @()
     )
 
     $resultsDir = Join-Path $OutputRoot $Label
     New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
 
     Write-Host "Running $Label tests with coverage..."
-    & dotnet test $ProjectPath -v minimal "-p:BaseOutputPath=$BaseOutputPath" --collect "XPlat Code Coverage" --settings $SettingsPath --results-directory $resultsDir
+    $testArguments = @(
+        "test",
+        $ProjectPath,
+        "-v", "minimal",
+        "-p:BaseOutputPath=$BaseOutputPath"
+    ) + $BuildProperties + @(
+        "--collect", "XPlat Code Coverage",
+        "--settings", $SettingsPath,
+        "--results-directory", $resultsDir
+    )
+    & dotnet @testArguments
     if ($LASTEXITCODE -ne 0) {
         throw "$Label tests failed."
     }
@@ -52,27 +91,34 @@ function Get-BaseOutputPath {
     return $baseOutput
 }
 
+$resolvedGxPath = Resolve-GxSdkPath
+
 Invoke-CoverageTest `
     -ProjectPath (Join-Path $repoRoot "src\GxMcp.Gateway.Tests\GxMcp.Gateway.Tests.csproj") `
     -Label "gateway" `
     -BaseOutputPath (Get-BaseOutputPath -Label "gateway") `
     -SettingsPath (Join-Path $PSScriptRoot "gateway.runsettings")
 
-$workerSdk = "C:\Program Files (x86)\GeneXus\GeneXus18\Artech.Architecture.Common.dll"
-if (Test-Path $workerSdk) {
+$previousGxPath = $env:GX_PATH
+if ($resolvedGxPath) {
+    Write-Host "Using GeneXus SDK from '$resolvedGxPath'."
+    $env:GX_PATH = $resolvedGxPath
     try {
         Invoke-CoverageTest `
             -ProjectPath (Join-Path $repoRoot "src\GxMcp.Worker.Tests\GxMcp.Worker.Tests.csproj") `
             -Label "worker" `
             -BaseOutputPath (Get-BaseOutputPath -Label "worker") `
-            -SettingsPath (Join-Path $PSScriptRoot "worker.runsettings")
+            -SettingsPath (Join-Path $PSScriptRoot "worker.runsettings") `
+            -BuildProperties @("-p:Platform=x86", "-p:GX_PATH=$resolvedGxPath")
     } catch {
         New-Item -ItemType File -Path (Join-Path $OutputRoot "worker.failed.txt") -Force | Out-Null
         Write-Host $_.Exception.Message -ForegroundColor Yellow
+    } finally {
+        $env:GX_PATH = $previousGxPath
     }
 } else {
     New-Item -ItemType File -Path (Join-Path $OutputRoot "worker.skipped.txt") -Force | Out-Null
-    Write-Host "GeneXus 18 SDK not installed; skipping Worker.Tests."
+    Write-Host "GeneXus 18 SDK not found. Set GX_PATH or pass -GxPath to include Worker.Tests."
 }
 
 Get-ChildItem -Path $OutputRoot -Recurse | ForEach-Object {

--- a/src/GxMcp.Gateway.Tests/GatewayProcessLeaseTests.cs
+++ b/src/GxMcp.Gateway.Tests/GatewayProcessLeaseTests.cs
@@ -112,8 +112,10 @@ namespace GxMcp.Gateway.Tests
                 var parsed2 = JsonConvert.DeserializeObject<GatewayLeaseRecord>(File.ReadAllText(leasePath));
                 Assert.Equal(Environment.ProcessId, parsed2!.ProcessId);
 
-                // No .tmp.* scratch files left in the lease directory.
-                Assert.Empty(Directory.GetFiles(leaseDir, "*.tmp.*"));
+                // No scratch file for this lease is left behind. Other gateway
+                // instances may legitimately publish their own lease concurrently.
+                var leaseTempPattern = Path.GetFileName(leasePath) + ".tmp.*";
+                Assert.Empty(Directory.GetFiles(leaseDir, leaseTempPattern));
             }
             finally
             {

--- a/src/GxMcp.Gateway.Tests/RouterContractCoverageTests.cs
+++ b/src/GxMcp.Gateway.Tests/RouterContractCoverageTests.cs
@@ -1,0 +1,218 @@
+using GxMcp.Gateway.Routers;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxMcp.Gateway.Tests
+{
+    public class RouterContractCoverageTests
+    {
+        [Theory]
+        [InlineData("genexus_delete_object", "{}", "Object", "Delete")]
+        [InlineData("genexus_worker_reload", "{}", "Object", "WorkerReload")]
+        [InlineData("genexus_validate_payload", "{}", "Write", "ValidatePayload")]
+        [InlineData("genexus_bulk_edit", "{}", "Write", "Bulk")]
+        [InlineData("genexus_sdk_probe", "{}", "SdkProbe", "Run")]
+        [InlineData("genexus_format", "{}", "Formatting", "Format")]
+        [InlineData("genexus_security", "{}", "Security", "audit_gam")]
+        [InlineData("genexus_edit_form", "{action:' insert '}", "WebFormEdit", "insert")]
+        [InlineData("genexus_run_object", "{}", "RunObject", "Resolve")]
+        [InlineData("genexus_explain", "{}", "Explain", "Explain")]
+        [InlineData("genexus_kb_readme", "{}", "KbReadme", "Generate")]
+        [InlineData("genexus_pr_description", "{}", "PrDescription", "Generate")]
+        [InlineData("genexus_multi_agent_lock", "{}", "MultiAgentLock", "status")]
+        [InlineData("genexus_memory", "{}", "Memory", "recall")]
+        [InlineData("genexus_what_if", "{}", "WhatIf", "Simulate")]
+        [InlineData("genexus_doctor", "{}", "Doctor", "Diagnose")]
+        [InlineData("genexus_tutorial", "{}", "Tutorial", "Step")]
+        [InlineData("genexus_playbook", "{}", "Playbook", "Read")]
+        [InlineData("genexus_gxserver", "{}", "GxServer", "Run")]
+        [InlineData("genexus_compare", "{}", "Compare", "Run")]
+        [InlineData("genexus_module", "{}", "Module", "Run")]
+        [InlineData("genexus_gam", "{}", "Gam", "Run")]
+        [InlineData("genexus_merge", "{}", "Merge", "Run")]
+        [InlineData("genexus_kb_version", "{}", "KbVersion", "Run")]
+        [InlineData("genexus_transfer", "{}", "Transfer", "Run")]
+        [InlineData("genexus_deploy", "{}", "Deploy", "Run")]
+        [InlineData("genexus_github", "{}", "Github", "CreatePr")]
+        [InlineData("genexus_ai_complete", "{}", "AiComplete", "Complete")]
+        [InlineData("genexus_voice", "{}", "Voice", "Intent")]
+        [InlineData("genexus_auto_test", "{}", "AutoTest", "Generate")]
+        [InlineData("genexus_reverse_pattern", "{}", "ReversePattern", "Infer")]
+        [InlineData("genexus_orient", "{}", "Orient", "Welcome")]
+        [InlineData("genexus_api", "{}", "Api", "list")]
+        [InlineData("genexus_wwp", "{}", "WwpAction", "Run")]
+        public void Operations_direct_routes_match_contract(string tool, string json, string module, string action)
+        {
+            AssertRoute(new OperationsRouter().ConvertToolCall(tool, JObject.Parse(json)), module, action);
+        }
+
+        [Theory]
+        [InlineData("genexus_create", "object", "Object", "Create")]
+        [InlineData("genexus_create", "object_atomic", "AtomicCreate", "Run")]
+        [InlineData("genexus_create", "popup", "Popup", "Create")]
+        [InlineData("genexus_create", "sd_panel_create", "SdPanel", "create")]
+        [InlineData("genexus_create", "sd_panel_inspect", "SdPanel", "inspect")]
+        [InlineData("genexus_create", "sd_panel_edit", "SdPanel", "edit")]
+        [InlineData("genexus_create", "save_as", "Object", "SaveAs")]
+        [InlineData("genexus_create", "scaffold", "Forge", "Scaffold")]
+        [InlineData("genexus_create", "translate", "Conversion", "TranslateTo")]
+        [InlineData("genexus_create", "sample", "Pattern", "GetSample")]
+        [InlineData("genexus_create", "template", "Write", "ApplyTemplate")]
+        [InlineData("genexus_create", "curl_procedure", "CurlProc", "Run")]
+        [InlineData("genexus_telemetry", "logs", "Object", "ReadLogs")]
+        [InlineData("genexus_telemetry", "friction_append", "FrictionLog", "Append")]
+        [InlineData("genexus_telemetry", "friction_tail", "FrictionLog", "Tail")]
+        [InlineData("genexus_telemetry", "learning_report", "Learning", "Report")]
+        [InlineData("genexus_telemetry", "profile_analyze", "Profile", "analyze")]
+        [InlineData("genexus_telemetry", "profile_hotspots", "Profile", "hotspots")]
+        [InlineData("genexus_telemetry", "profile_correlate", "Profile", "correlate")]
+        [InlineData("genexus_io", "asset_find", "Asset", "Find")]
+        [InlineData("genexus_io", "asset_read", "Asset", "Read")]
+        [InlineData("genexus_io", "asset_write", "Asset", "Write")]
+        [InlineData("genexus_io", "export_part", "Object", "ExportText")]
+        [InlineData("genexus_io", "import_part", "Object", "ImportText")]
+        [InlineData("genexus_io", "export_unified", "Export", "Unified")]
+        [InlineData("genexus_io", "screenshot_publish", "ScreenshotPublish", "Publish")]
+        [InlineData("genexus_io", "ocr", "Ocr", "Run")]
+        [InlineData("genexus_versioning", "history_list", "History", "list")]
+        [InlineData("genexus_versioning", "history_get", "History", "get_source")]
+        [InlineData("genexus_versioning", "history_save", "History", "save")]
+        [InlineData("genexus_versioning", "history_restore", "History", "restore")]
+        [InlineData("genexus_versioning", "undo", "Undo", "Undo")]
+        [InlineData("genexus_versioning", "time_travel", "TimeTravel", "Recover")]
+        [InlineData("genexus_versioning", "blame", "Blame", "Get")]
+        [InlineData("genexus_versioning", "diff", "Diff", "textVsText")]
+        [InlineData("genexus_versioning", "diff_generated", "GeneratedDiff", "Diff")]
+        [InlineData("genexus_db", "drift_check", "DbDrift", "Check")]
+        [InlineData("genexus_db", "drift_report", "DbDrift", "Report")]
+        [InlineData("genexus_db", "optimize_analyze", "DbOptimize", "Analyze")]
+        [InlineData("genexus_db", "optimize_suggest", "DbOptimize", "SuggestIndexes")]
+        [InlineData("genexus_db", "optimize_report", "DbOptimize", "Report")]
+        [InlineData("genexus_db", "sql_ddl", "Analyze", "GetSQL")]
+        [InlineData("genexus_db", "sql_navigation", "Analyze", "GetSqlForNavigation")]
+        [InlineData("genexus_db", "sample_data", "Analyze", "GenerateSampleData")]
+        [InlineData("genexus_db", "types_list", "types", "list")]
+        [InlineData("genexus_db", "types_describe", "types", "describe")]
+        [InlineData("genexus_db", "types_validate", "types", "validate_value")]
+        [InlineData("genexus_db", "reorg_impact", "ReorgImpact", "Run")]
+        [InlineData("genexus_db", "reorg_preview", "ReorgImpact", "Preview")]
+        [InlineData("genexus_db", "translations_import", "Analyze", "TranslationsImport")]
+        [InlineData("genexus_browser", "smoke", "smoke_test", "Run")]
+        [InlineData("genexus_browser", "a11y", "a11y_audit", "Audit")]
+        [InlineData("genexus_browser", "wcag", "WcagCheck", "Check")]
+        [InlineData("genexus_browser", "capture", "browser_capture", "Capture")]
+        [InlineData("genexus_browser", "cross", "CrossBrowser", "Run")]
+        [InlineData("genexus_browser", "preview", "Preview", "Render")]
+        public void Operations_umbrella_actions_match_contract(string tool, string actionName, string module, string action)
+        {
+            var args = new JObject { ["action"] = actionName, ["name"] = "SampleObject", ["type"] = "Procedure" };
+            AssertRoute(new OperationsRouter().ConvertToolCall(tool, args), module, action);
+        }
+
+        [Theory]
+        [InlineData("linter", "Linter", "linter")]
+        [InlineData("navigation", "Analyze", "GetNavigation")]
+        [InlineData("hierarchy", "Analyze", "GetHierarchy")]
+        [InlineData("impact", "Analyze", "ImpactAnalysis")]
+        [InlineData("data_context", "Analyze", "GetDataContext")]
+        [InlineData("ui_context", "UI", "GetUIContext")]
+        [InlineData("pattern_metadata", "Analyze", "GetPatternMetadata")]
+        [InlineData("summary", "Analyze", "Summarize")]
+        [InlineData("code_metrics", "Analyze", "GetCodeMetrics")]
+        [InlineData("kb_stats", "KbStats", "Run")]
+        [InlineData("table_relations", "TableRelations", "Run")]
+        [InlineData("explain", "Analyze", "ExplainCode")]
+        [InlineData("callers", "Analyze", "FindCallerSites")]
+        [InlineData("event_flow", "Analyze", "GetEventFlow")]
+        [InlineData("dependency_heatmap", "Analyze", "DependencyHeatmap")]
+        [InlineData("cross_platform_impact", "Analyze", "CrossPlatformImpact")]
+        [InlineData("parent_context", "Analyze", "ParentContext")]
+        [InlineData("unknown", "Analyze", "Analyze")]
+        public void Analyze_modes_match_contract(string mode, string module, string action)
+        {
+            var args = new JObject { ["mode"] = mode, ["name"] = "SampleObject", ["type"] = "Procedure" };
+            AssertRoute(new AnalyzeRouter().ConvertToolCall("genexus_analyze", args), module, action);
+        }
+
+        [Theory]
+        [InlineData("genexus_inspect", "Analyze", "GetConversionContext")]
+        [InlineData("genexus_inject_context", "Analyze", "InjectContext")]
+        [InlineData("genexus_get_signature", "Analyze", "GetParameters")]
+        [InlineData("genexus_linter", "Linter", "linter")]
+        [InlineData("genexus_get_navigation", "Analyze", "GetNavigation")]
+        public void Analyze_direct_routes_match_contract(string tool, string module, string action)
+        {
+            AssertRoute(new AnalyzeRouter().ConvertToolCall(tool, new JObject()), module, action);
+        }
+
+        [Theory]
+        [InlineData("build", "Build", "Build")]
+        [InlineData("cancel", "Build", "Cancel")]
+        [InlineData("specify", "Build", "Specify")]
+        [InlineData("rebuild", "Build", "RebuildAll")]
+        [InlineData("reorg", "Build", "Reorg")]
+        [InlineData("reorg_preview", "Build", "ReorgPreview")]
+        [InlineData("validate", "Validation", "Check")]
+        [InlineData("validate-kb", "KB", "ValidateConditions")]
+        [InlineData("snapshots-list", "KB", "ListPatternSnapshots")]
+        [InlineData("snapshots-restore", "KB", "RestorePatternSnapshot")]
+        [InlineData("sync", "Build", "Sync")]
+        [InlineData("index", "KB", "BulkIndex")]
+        public void Lifecycle_actions_match_contract(string lifecycleAction, string module, string action)
+        {
+            var args = new JObject { ["action"] = lifecycleAction, ["target"] = "SampleObject" };
+            AssertRoute(new SystemRouter().ConvertToolCall("genexus_lifecycle", args), module, action);
+        }
+
+        [Fact]
+        public void Lifecycle_status_result_and_compile_check_cover_special_contracts()
+        {
+            var router = new SystemRouter();
+            AssertRoute(router.ConvertToolCall("genexus_lifecycle", JObject.Parse("{action:'build',mode:'compile_check'}")), "Build", "CompileCheck");
+            AssertRoute(router.ConvertToolCall("genexus_lifecycle", JObject.Parse("{action:'status',target:'job',wait:999}")), "Build", "Status");
+            AssertRoute(router.ConvertToolCall("genexus_lifecycle", JObject.Parse("{action:'status',wait:-1}")), "KB", "GetIndexStatus");
+            AssertRoute(router.ConvertToolCall("genexus_lifecycle", JObject.Parse("{action:'result',target:'job'}")), "Build", "Result");
+            Assert.Null(router.ConvertToolCall("genexus_lifecycle", JObject.Parse("{action:'result'}")));
+        }
+
+        [Theory]
+        [InlineData("genexus_doc", "{action:'wiki'}", "Wiki", "Generate")]
+        [InlineData("genexus_doc", "{action:'visualize'}", "Visualizer", "Generate")]
+        [InlineData("genexus_doc", "{action:'health'}", "Health", "GetReport")]
+        [InlineData("genexus_test", "{}", "Test", "Run")]
+        [InlineData("genexus_kb", "{action:'set_startup'}", "KB", "SetStartupObject")]
+        [InlineData("genexus_kb", "{action:'get_startup'}", "KB", "GetStartupObject")]
+        [InlineData("genexus_kb_explorer", "{}", "KbExplorer", "Locate")]
+        [InlineData("genexus_navigation", "{}", "Navigation", "View")]
+        [InlineData("genexus_build_plan", "{}", "BuildPlan", "Generate")]
+        [InlineData("genexus_validate", "{}", "Validation", "Check")]
+        [InlineData("genexus_build", "{action:'Build'}", "Build", "Build")]
+        public void System_direct_routes_match_contract(string tool, string json, string module, string action)
+        {
+            AssertRoute(new SystemRouter().ConvertToolCall(tool, JObject.Parse(json)), module, action);
+        }
+
+        [Fact]
+        public void Invalid_routes_are_explicit_or_null()
+        {
+            var operations = new OperationsRouter();
+            AssertRoute(operations.ConvertToolCall("genexus_create", new JObject()), "Error", "InvalidAction");
+            AssertRoute(operations.ConvertToolCall("genexus_telemetry", new JObject()), "Error", "InvalidAction");
+            AssertRoute(operations.ConvertToolCall("genexus_io", new JObject()), "Error", "InvalidAction");
+            AssertRoute(operations.ConvertToolCall("genexus_versioning", new JObject()), "Error", "InvalidAction");
+            AssertRoute(operations.ConvertToolCall("genexus_db", new JObject()), "Error", "InvalidAction");
+            AssertRoute(operations.ConvertToolCall("genexus_browser", new JObject()), "Error", "InvalidAction");
+            Assert.Null(operations.ConvertToolCall("unknown", new JObject()));
+            Assert.Null(new AnalyzeRouter().ConvertToolCall("unknown", new JObject()));
+            Assert.Null(new SystemRouter().ConvertToolCall("unknown", new JObject()));
+        }
+
+        private static void AssertRoute(object? result, string module, string action)
+        {
+            Assert.NotNull(result);
+            var routed = JObject.FromObject(result!);
+            Assert.Equal(module, (string?)routed["module"]);
+            Assert.Equal(action, (string?)routed["action"]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- resolve the GeneXus SDK from `-GxPath`, `GX_PATH`, then the default installation directory
- run Worker coverage as x86 and fail explicitly for an invalid configured SDK path
- add 138 router contract scenarios and raise Gateway line coverage from 57.44% to 60.98% without exclusions
- raise the documented and CI coverage floor to 60%
- make the concurrent lease assertion scope temporary files to its own lease

## Validation

- Gateway coverage: 1,024 passed, 7 skipped, 60.98% line rate
- focused Worker verifier coverage with a non-default SDK: 7 passed, 87.2% line rate for the verifier
- CLI: 54 passed
- Nexus IDE: compile passed; 100 tests passed; lint completed without errors
- LLM contract smoke: passed
- invalid configured SDK path: rejected before test execution

## Notes

- No coverage exclusions were added.
- No Knowledge Base was specified, generated, built, reorganized, deployed, or modified.
- Examples and test identifiers are synthetic.