### PR TITLE
fix(gateway): preserve create variable name alias

### DIFF
--- a/src/GxMcp.Gateway.Tests/Fixtures/Contract/Discovery/tools-list.response.json
+++ b/src/GxMcp.Gateway.Tests/Fixtures/Contract/Discovery/tools-list.response.json
@@ -746,9 +746,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "varName"
-              ],
               "type": "object"
             },
             "type": "array"

--- a/src/GxMcp.Gateway.Tests/ToolSchemaCompatibilityTests.cs
+++ b/src/GxMcp.Gateway.Tests/ToolSchemaCompatibilityTests.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxMcp.Gateway.Tests;
+
+public sealed class ToolSchemaCompatibilityTests
+{
+    [Fact]
+    public void Apply_PreservesLegacyNameAliasForAtomicCreateVariables()
+    {
+        var definitions = JArray.Parse("""
+            [{
+              "name": "genexus_create",
+              "inputSchema": {
+                "properties": {
+                  "variables": {
+                    "items": {
+                      "required": ["varName"],
+                      "properties": {
+                        "name": { "type": "string" },
+                        "varName": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }]
+            """);
+
+        ToolSchemaCompatibility.Apply(definitions);
+
+        Assert.Null(definitions[0]?["inputSchema"]?["properties"]?["variables"]?["items"]?["required"]);
+        Assert.NotNull(definitions[0]?["inputSchema"]?["properties"]?["variables"]?["items"]?["properties"]?["name"]);
+        Assert.NotNull(definitions[0]?["inputSchema"]?["properties"]?["variables"]?["items"]?["properties"]?["varName"]);
+    }
+}

--- a/src/GxMcp.Gateway/GatewayArgsValidator.cs
+++ b/src/GxMcp.Gateway/GatewayArgsValidator.cs
@@ -225,6 +225,7 @@ namespace GxMcp.Gateway
                 try
                 {
                     _toolDefs = JArray.Parse(File.ReadAllText(path));
+                    ToolSchemaCompatibility.Apply(_toolDefs);
                 }
                 catch
                 {

--- a/src/GxMcp.Gateway/McpRouter.cs
+++ b/src/GxMcp.Gateway/McpRouter.cs
@@ -185,6 +185,7 @@ namespace GxMcp.Gateway
                 {
                     string json = File.ReadAllText(defPath);
                     var parsed = JArray.Parse(json);
+                    ToolSchemaCompatibility.Apply(parsed);
                     // MCP clients cache tools/list aggressively; deterministic ordering
                     // keeps discovery diffs stable and avoids model-visible churn when
                     // the source JSON is edited in a different order.

--- a/src/GxMcp.Gateway/ToolSchemaCompatibility.cs
+++ b/src/GxMcp.Gateway/ToolSchemaCompatibility.cs
@@ -1,0 +1,40 @@
+using Newtonsoft.Json.Linq;
+
+namespace GxMcp.Gateway;
+
+/// <summary>
+/// Preserves request shapes that were already published by an earlier
+/// operational baseline when a newer catalog accidentally narrows them.
+/// Keep every exception explicit and covered by a regression test.
+/// </summary>
+internal static class ToolSchemaCompatibility
+{
+    public static void Apply(JArray definitions)
+    {
+        var create = definitions.OfType<JObject>()
+            .FirstOrDefault(tool => string.Equals(
+                tool["name"]?.ToString(),
+                "genexus_create",
+                StringComparison.Ordinal));
+        var required = create?["inputSchema"]?["properties"]?["variables"]?["items"]?["required"] as JArray;
+        if (required is null)
+        {
+            return;
+        }
+
+        // The Worker accepts both `name` and `varName` for object_atomic variables.
+        // v2.37 advertised both as optional; requiring only `varName` in v2.38
+        // would reject previously valid callers before they reached the Worker.
+        foreach (var token in required
+                     .Where(token => string.Equals(token?.ToString(), "varName", StringComparison.Ordinal))
+                     .ToArray())
+        {
+            token.Remove();
+        }
+
+        if (required.Count == 0)
+        {
+            (required.Parent as JProperty)?.Remove();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the previously advertised `name` alias for `genexus_create.variables[]`
- keep `name` and `varName` optional at MCP schema validation while the Worker accepts either
- apply the compatibility transform consistently to discovery and argument validation

## Why

The Worker accepts both field names, and an earlier catalog advertised both as optional. Requiring only `varName` at the Gateway rejects existing valid callers before their request reaches the Worker.

## Testing

- `dotnet test src/GxMcp.Gateway.Tests/GxMcp.Gateway.Tests.csproj -c Release`
- 887 passed, 7 skipped, 0 failed
- operational read-only smoke across supported GeneXus profiles: 47 tools discovered and identity checks passed

No Knowledge Base content or environment-specific configuration is included in this change.