### PR TITLE
fix: detect the real User Control degradation signature (#103 item 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Fixed
+
+- **User Control degradation detection no longer fires on healthy builds.** The post-build
+  evidence gate required one `setProp("Gx Control Type", ...)` binding per `gx.uc.getNew(...)`
+  instance, but GeneXus emits that property only sporadically: in a reference KB with 32 User
+  Control objects, exactly one carried it — and IDE-generated output was no different from
+  MCP-generated output. Every other build was reported as `SucceededWithGaps` with a
+  `[user-control-degraded]` warning, which buried the real failure in noise. Detection now keys
+  on the signature actually observed in degraded output: the control-name argument of
+  `gx.uc.getNew(...)` emitted as the literal string `"this"` instead of the control's name,
+  and/or a generated `.js` that lost every `setProp(...)` binding. Measured against a real KB,
+  the new gate flags 5 of 5 genuinely degraded files and 0 of 28 healthy IDE-generated ones
+  (the previous gate flagged 27 of those 28). Fixes #103 item 4.
+
 ## v2.41.10 - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   and/or a generated `.js` that lost every `setProp(...)` binding. Measured against a real KB,
   the new gate flags 5 of 5 genuinely degraded files and 0 of 28 healthy IDE-generated ones
   (the previous gate flagged 27 of those 28). Fixes #103 item 4.
+- Thanks to [@danielkrueger](https://github.com/danielkrueger) for identifying the real User Control degradation signature and updating the evidence gate — see [PR #108](https://github.com/lennix1337/Genexus18MCP/pull/108).
 
 ## v2.41.10 - 2026-08-19
 

--- a/src/GxMcp.Worker.Tests/BuildServiceTests.cs
+++ b/src/GxMcp.Worker.Tests/BuildServiceTests.cs
@@ -855,8 +855,12 @@ namespace GxMcp.Worker.Tests
             }
         }
 
+        // issue #103 item 4 — the generator emits setProp("Gx Control Type",...) only
+        // sporadically (1 of 32 User Control objects in the reference KB carried it, IDE
+        // builds included). Its absence is the norm, not a degradation, and must not raise
+        // a warning: a detector that fires on every healthy build buries the real signal.
         [Fact]
-        public void GenerateEvidence_DetectsPartialUserControlTypeBindings()
+        public void GenerateEvidence_IgnoresMissingGxControlTypeBinding()
         {
             string objectName = "Dashboard";
             string tempKb = Path.Combine(Path.GetTempPath(), "gxmcp-test-" + Guid.NewGuid().ToString("N"));
@@ -864,21 +868,76 @@ namespace GxMcp.Worker.Tests
             Directory.CreateDirectory(web);
             File.WriteAllText(Path.Combine(web, objectName + ".cs"), "class Dashboard {}");
 
-            var js = string.Join("\n", Enumerable.Range(0, 13).Select(i =>
-                "var n" + i + " = gx.uc.getNew('Control" + i + "');\n"
-                + (i < 12
-                    ? "n" + i + ".setProp(\"Gx Control Type\",\"Gxcontroltype\",\"\",\"int\");"
-                    : string.Empty)));
+            // Healthy JS as the IDE emits it: real control name, full property list,
+            // no "Gx Control Type" binding anywhere.
+            string js = "n=gx.uc.getNew(this,6,0,\"DashboardViewer\",\"DV1Container\",\"Dashboardviewer1\",\"DV1\");"
+                      + "n.setProp(\"Class\",\"Class\",\"DashboardViewer\",\"str\");"
+                      + "n.setProp(\"Visible\",\"Visible\",!0,\"bool\");";
             File.WriteAllText(Path.Combine(web, objectName.ToLowerInvariant() + ".js"), js);
 
             var previousKb = Environment.GetEnvironmentVariable("GX_KB_PATH");
             Environment.SetEnvironmentVariable("GX_KB_PATH", tempKb);
             try
             {
-                Assert.NotNull(BuildService.DetectUserControlBindingDegradation(
+                Assert.Null(BuildService.DetectUserControlBindingDegradation(
                     objectName,
                     Path.Combine(web, objectName.ToLowerInvariant() + ".js"),
                     js));
+
+                var svc = new BuildService();
+                var status = new BuildService.BuildTaskStatus
+                {
+                    TaskId = Guid.NewGuid().ToString("N").Substring(0, 8),
+                    Action = "Build",
+                    Target = objectName,
+                    Status = "Succeeded",
+                    Phase = "Done",
+                    StartedAt = DateTime.UtcNow.AddSeconds(-1),
+                    DirtyAtStart = new List<string> { objectName }
+                };
+
+                var method = typeof(BuildService).GetMethod("AttachGenerateEvidence", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(method);
+                method!.Invoke(svc, new object[] { status, "Build", new List<string> { objectName } });
+
+                var evidence = (JObject)status.GenerateEvidence!;
+                Assert.Null(evidence["degradedUserControls"]);
+                Assert.DoesNotContain(status.Warnings, w => w.Contains("user-control-degraded"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("GX_KB_PATH", previousKb);
+                try { Directory.Delete(tempKb, true); } catch { }
+            }
+        }
+
+        // The real degradation, as measured against IDE baselines: the control name comes
+        // out as the literal string "this" and every setProp binding is gone.
+        [Fact]
+        public void GenerateEvidence_DetectsDegradedUserControlSignature()
+        {
+            string objectName = "GrafComercial";
+            string tempKb = Path.Combine(Path.GetTempPath(), "gxmcp-test-" + Guid.NewGuid().ToString("N"));
+            string web = Path.Combine(tempKb, "NETCoreMySQL", "web");
+            Directory.CreateDirectory(web);
+            File.WriteAllText(Path.Combine(web, objectName + ".cs"), "class GrafComercial {}");
+
+            string js = "gx.uc.getNew(this,10,5,\"QueryViewer\",this.CmpContext+\"QV1Container\",\"this\",\"QV1\");"
+                      + "i=this.QV1Container;i.setC2ShowFunction(function(n){n.show()});this.setUserControl(i);";
+            string jsPath = Path.Combine(web, objectName.ToLowerInvariant() + ".js");
+            File.WriteAllText(jsPath, js);
+
+            var previousKb = Environment.GetEnvironmentVariable("GX_KB_PATH");
+            Environment.SetEnvironmentVariable("GX_KB_PATH", tempKb);
+            try
+            {
+                var direct = BuildService.DetectUserControlBindingDegradation(objectName, jsPath, js);
+                Assert.NotNull(direct);
+                Assert.Equal(1, direct!["userControlInstances"]!.Value<int>());
+                Assert.Equal(0, direct["propertyBindings"]!.Value<int>());
+                Assert.Contains((JArray)direct["placeholderControlNames"]!,
+                    t => string.Equals((string)t, "QueryViewer", StringComparison.OrdinalIgnoreCase));
+
                 var svc = new BuildService();
                 var status = new BuildService.BuildTaskStatus
                 {
@@ -899,8 +958,7 @@ namespace GxMcp.Worker.Tests
                 Assert.False(evidence["ok"]!.Value<bool>(), evidence.ToString());
                 var degraded = (JArray)evidence["degradedUserControls"]!;
                 Assert.Single(degraded);
-                Assert.Equal(13, degraded[0]["expectedBindings"]!.Value<int>());
-                Assert.Equal(12, degraded[0]["actualBindings"]!.Value<int>());
+                Assert.Equal(0, degraded[0]["propertyBindings"]!.Value<int>());
             }
             finally
             {
@@ -917,8 +975,8 @@ namespace GxMcp.Worker.Tests
             string web = Path.Combine(tempKb, "NETCoreMySQL", "web");
             Directory.CreateDirectory(web);
 
-            string js = "var n = gx.uc.getNew('SampleViewer');\n"
-                      + "n.setProp(\"Visible\",\"Visible\",true,\"bool\");";
+            string js = "gx.uc.getNew(this,3,0,'SampleViewer','SV1Container','this','SV1');\n"
+                      + "i=this.SV1Container;this.setUserControl(i);";
             File.WriteAllText(Path.Combine(web, objectName.ToLowerInvariant() + ".js"), js);
 
             string previousKb = Environment.GetEnvironmentVariable("GX_KB_PATH");
@@ -945,8 +1003,8 @@ namespace GxMcp.Worker.Tests
                 Assert.False(evidence["ok"]!.Value<bool>(), evidence.ToString());
                 var degraded = (JArray)evidence["degradedUserControls"]!;
                 Assert.Single(degraded);
-                Assert.Equal(1, degraded[0]["expectedBindings"]!.Value<int>());
-                Assert.Equal(0, degraded[0]["actualBindings"]!.Value<int>());
+                Assert.Equal(1, degraded[0]["userControlInstances"]!.Value<int>());
+                Assert.Equal(0, degraded[0]["propertyBindings"]!.Value<int>());
             }
             finally
             {

--- a/src/GxMcp.Worker/Services/BuildService.cs
+++ b/src/GxMcp.Worker/Services/BuildService.cs
@@ -24,10 +24,14 @@ namespace GxMcp.Worker.Services
         private IndexCacheService _indexCacheService;
         private CallerGraphService _callerGraphService;
         private static readonly ConcurrentDictionary<string, BuildTaskStatus> _tasks = new ConcurrentDictionary<string, BuildTaskStatus>();
+        // The generator's User Control factory call together with its (non-nested)
+        // argument list: gx.uc.getNew(this,6,0,"DashboardViewer","DV1Container","Dashboardviewer1","DV1").
         private static readonly Regex _userControlFactoryRegex = new Regex(
-            @"\bgx\.uc\.getNew\s*\(", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex _userControlTypeBindingRegex = new Regex(
-            @"\bsetProp\s*\(\s*['""]Gx Control Type['""]\s*,", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            @"\bgx\.uc\.getNew\s*\(([^()]*)\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        // Any runtime property binding emitted for a User Control instance. A healthy
+        // instance always carries at least Class/Visible; a degraded one carries none.
+        private static readonly Regex _userControlPropertyBindingRegex = new Regex(
+            @"\.setProp\s*\(", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // issue #42 — builds whose RunBuild is genuinely executing right now, keyed by
         // taskId. Add on entry, remove in finally. This is the source of truth for
@@ -1702,23 +1706,95 @@ namespace GxMcp.Worker.Services
             return t.Contains(":") ? t.Substring(t.LastIndexOf(':') + 1).Trim() : t;
         }
 
+        // Split a JS argument list on top-level commas, ignoring commas inside string
+        // literals. Good enough for the generator's flat factory-call argument lists
+        // (the caller only feeds it argument lists that contain no nested parentheses).
+        internal static List<string> SplitJsArguments(string argList)
+        {
+            var args = new List<string>();
+            if (argList == null) return args;
+            var sb = new StringBuilder();
+            char quote = '\0';
+            for (int i = 0; i < argList.Length; i++)
+            {
+                char c = argList[i];
+                if (quote != '\0')
+                {
+                    sb.Append(c);
+                    if (c == '\\' && i + 1 < argList.Length) { sb.Append(argList[++i]); continue; }
+                    if (c == quote) quote = '\0';
+                    continue;
+                }
+                if (c == '\'' || c == '"') { quote = c; sb.Append(c); continue; }
+                if (c == ',') { args.Add(sb.ToString().Trim()); sb.Length = 0; continue; }
+                sb.Append(c);
+            }
+            if (sb.Length > 0 || args.Count > 0) args.Add(sb.ToString().Trim());
+            return args;
+        }
+
+        // True when the argument is the string literal "this" — the placeholder the
+        // generator emits for a User Control whose control name it failed to resolve.
+        private static bool IsThisPlaceholder(string arg)
+        {
+            if (string.IsNullOrEmpty(arg) || arg.Length < 3) return false;
+            char q = arg[0];
+            if ((q != '\'' && q != '"') || arg[arg.Length - 1] != q) return false;
+            return string.Equals(arg.Substring(1, arg.Length - 2).Trim(), "this", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// issue #103 item 4. Detects a generated .js whose User Control came out degraded —
+        /// the failure mode that renders &lt;span&gt;undefined&lt;/span&gt; at runtime and, once the
+        /// screen is saved, writes the bound attribute back empty.
+        ///
+        /// The signature of a degraded instance, measured against IDE-generated baselines, is:
+        ///   - the control-name argument of gx.uc.getNew(...) emitted as the literal string
+        ///     "this" instead of the control's name (e.g. "Qv1"), and/or
+        ///   - not a single setProp(...) binding left in the file.
+        ///
+        /// Deliberately NOT a per-instance "Gx Control Type" count: that property is emitted
+        /// only sporadically by the generator (1 of 32 User Control objects in the reference
+        /// KB carried it, IDE builds included), so requiring one per gx.uc.getNew made every
+        /// healthy build report a degradation and buried the real one in the noise.
+        /// </summary>
         internal static JObject DetectUserControlBindingDegradation(string objectName, string jsPath, string jsText)
         {
             if (string.IsNullOrEmpty(jsText)) return null;
 
-            int expectedBindings = _userControlFactoryRegex.Matches(jsText).Count;
-            if (expectedBindings == 0) return null;
+            var factoryCalls = _userControlFactoryRegex.Matches(jsText);
+            if (factoryCalls.Count == 0) return null;
 
-            int actualBindings = _userControlTypeBindingRegex.Matches(jsText).Count;
-            if (actualBindings >= expectedBindings) return null;
+            var placeholders = new JArray();
+            foreach (Match m in factoryCalls)
+            {
+                var args = SplitJsArguments(m.Groups[1].Value);
+                // parentObject, ucId, lastId, className, containerName, controlName, fieldName
+                if (args.Count < 6) continue;
+                if (!IsThisPlaceholder(args[5])) continue;
+                placeholders.Add(args[3].Trim('\'', '"'));
+            }
+
+            int propertyBindings = _userControlPropertyBindingRegex.Matches(jsText).Count;
+            bool noBindings = propertyBindings == 0;
+            if (placeholders.Count == 0 && !noBindings) return null;
+
+            string reason;
+            if (placeholders.Count > 0 && noBindings)
+                reason = "User Control JS lost every setProp binding and emitted \"this\" as the control name.";
+            else if (placeholders.Count > 0)
+                reason = "User Control JS emitted \"this\" as the control name instead of the control's name.";
+            else
+                reason = "User Control JS contains gx.uc.getNew instances but not a single setProp binding.";
 
             return new JObject
             {
                 ["object"] = objectName,
                 ["jsPath"] = jsPath,
-                ["expectedBindings"] = expectedBindings,
-                ["actualBindings"] = actualBindings,
-                ["reason"] = "User Control JS contains fewer Gx Control Type bindings than gx.uc.getNew instances."
+                ["userControlInstances"] = factoryCalls.Count,
+                ["propertyBindings"] = propertyBindings,
+                ["placeholderControlNames"] = placeholders,
+                ["reason"] = reason
             };
         }
 
@@ -2064,10 +2140,12 @@ namespace GxMcp.Worker.Services
                 lock (status._lock)
                 {
                     var names = string.Join(", ", degradedUserControls.Select(x => (string)x["object"]));
-                    status.Warnings.Add("[user-control-degraded] User Control JS generated without setProp for: " + names);
+                    status.Warnings.Add("[user-control-degraded] User Control JS generated without property bindings for: " + names);
                     status.WarningCount++;
                     if (string.IsNullOrEmpty(status.Hint))
-                        status.Hint = "User Control degradation detected: generated JS for " + names + " missing setProp bindings. Verify UserControls directory.";
+                        status.Hint = "User Control degradation detected: generated JS for " + names + " lost its setProp bindings "
+                            + "(the control renders as <span>undefined</span> and saving the screen writes the bound attribute back empty). "
+                            + "Regenerate the object from the IDE and compare the setProp list against a known-good build.";
                 }
             }
             if (upToDate.Count > 0)


### PR DESCRIPTION
## Problem

The post-build evidence gate flagged healthy builds as degraded. `DetectUserControlBindingDegradation` required one `setProp("Gx Control Type", ...)` binding per `gx.uc.getNew(...)` instance, so any generated `.js` without that property produced a `[user-control-degraded]` warning and `effective_status: SucceededWithGaps`.

That premise does not hold: GeneXus emits `Gx Control Type` only sporadically. In a reference KB (GX 18 U5, 32 objects with User Controls, two output folders) the property appeared in exactly **one** file per folder — and in a *different* file in each. Output generated by the IDE was no different from output generated through the MCP, so its absence is the norm, not a degradation.

The practical effect was that the gate fired on virtually every build and buried the failure it was meant to catch.

## The real signature

The degradation that actually matters — the one that renders `<span>undefined</span>` at runtime and, once the screen is saved, writes the bound attribute back empty — has a distinct signature in the generated `.js`:

```diff
- gx.uc.getNew(this,10,5,"QueryViewer",this.CmpContext+"QV1Container","Qv1","QV1");
+ gx.uc.getNew(this,10,5,"QueryViewer",this.CmpContext+"QV1Container","this","QV1");
```

The control-name argument comes out as the literal string `"this"` instead of the control's name, and every `setProp(...)` binding is gone. Detection now keys on that (placeholder control name and/or zero property bindings), and the evidence payload reports `userControlInstances` / `propertyBindings` / `placeholderControlNames` instead of the old expected/actual counts.

## Measurements

Against a real KB, comparing the two output folders of the same objects:

| Folder | Genuinely degraded | New gate | Old gate |
|---|---|---|---|
| `smtweb\web` (28 UC files) | 5 | **5** flagged | 27 flagged |
| `Producao\web` (28 UC files, IDE-generated) | 0 | **0** flagged | 27 flagged |

## Verification

- `dotnet test`: full suite **1956 passed / 4 skipped / 0 failed**.
- Live against GeneXus 18 U5 with the rebuilt worker:
  - healthy object (`Dashboard`, 12 `setProp`, no `Gx Control Type`) → `Status: Succeeded`, 0 warnings, `generateEvidence.ok: true`. The same build reported `SucceededWithGaps` before this change.
  - degraded object (`GrafComercial`) → warning raised as expected:

```json
"degradedUserControls": [{
  "object": "GrafComercial",
  "userControlInstances": 1,
  "propertyBindings": 0,
  "placeholderControlNames": ["QueryViewer"],
  "reason": "User Control JS lost every setProp binding and emitted \"this\" as the control name."
}]
```

Fixes #103 item 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVJRH9gkve9Cs1HDkPX3qG
