### PR TITLE
fix(worker): stop wiping Team Development local changes on every write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Worker object writes from advancing the model-level Team Development commit baseline, so earlier local changes remain pending while IDE refreshes continue through `LastObjectsVersionDate` ([#145](https://github.com/lennix1337/Genexus18MCP/pull/145); contributed by @elianferreira).
+
 ## v3.0.3 - 2026-09-08
 
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -60,6 +60,7 @@ Precedence is: tool `auth` argument > these env vars > built-in default.
 |----------|---------|---------|
 | `GXMCP_TEST_KB` | Absolute path to the verified disposable synthetic KB used by `scripts/test-live.ps1` and the release preflight. | unset (live gate skipped) |
 | `GXMCP_TEST_FIXTURE` | Path to the fixture attestation JSON matching `GXMCP_TEST_KB`; it must prove synthetic data and database isolation. | unset (live gate skipped) |
+| `GXMCP_TEAMDEV_PENDING_NAME` | Name of a pre-seeded object with an IDE-created Team Development pending change for the opt-in Gateway regression test. | unset (IDE-origin regression skipped) |
 | `GXMCP_REQUIRE_LIVE_BUILD_ALL` | Set to `1` to require the native Build All evidence gate during release preflight. Missing fixtures or an unavailable GeneXus cloud `User` fail the required gate. | off |
 
 ## Timeouts / budgets

--- a/src/GxMcp.Gateway.Tests/E2ELiveSmokeTests.cs
+++ b/src/GxMcp.Gateway.Tests/E2ELiveSmokeTests.cs
@@ -538,15 +538,15 @@ namespace GxMcp.Gateway.Tests
             var statusPayload = LiveGatewayHarness.ParseToolPayload(statusResponse);
             Assert.NotNull(statusPayload);
             var status = statusPayload!["result"] as JObject ?? statusPayload;
-            if (status["connected"]?.ToObject<bool?>() != true)
+            if (status["connected"]?.ToObject<bool?>() != true ||
+                !string.Equals(status["source"]?.ToString(), "sdk:ITeamDevClientService", StringComparison.Ordinal))
             {
                 throw SkipException.ForSkip(
-                    "The configured live KB is not linked to GeneXus Team Development; " +
+                    "The configured live KB does not expose the SDK Team Development service; " +
                     "set GXMCP_TEST_KB to a linked disposable KB to run this regression.");
             }
 
-            string tickHex = DateTime.UtcNow.Ticks.ToString("X");
-            string stamp = tickHex.Substring(tickHex.Length - 8).ToLowerInvariant();
+            string stamp = Guid.NewGuid().ToString("N").Substring(0, 8);
             string first = "TestTeamDevA" + stamp;
             string second = "TestTeamDevB" + stamp;
 
@@ -575,6 +575,9 @@ namespace GxMcp.Gateway.Tests
                     "first edit failed: " + firstEdit.ToString(Newtonsoft.Json.Formatting.None));
 
                 var afterFirst = await ReadTeamDevelopmentPendingNamesAsync();
+                // GetLocalChanges observes the model-level pending state regardless of whether
+                // the first change came from the IDE or this worker; using the MCP path keeps
+                // the regression self-contained while exercising the same SDK read.
                 Assert.True(
                     afterFirst.Contains(first),
                     "The first MCP write must appear in the Team Development pending list.");
@@ -611,8 +614,14 @@ namespace GxMcp.Gateway.Tests
             }
             finally
             {
-                await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = second, ["confirm"] = true });
-                await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = first, ["confirm"] = true });
+                try
+                {
+                    await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = second, ["confirm"] = true });
+                }
+                finally
+                {
+                    await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = first, ["confirm"] = true });
+                }
             }
         }
     }

--- a/src/GxMcp.Gateway.Tests/E2ELiveSmokeTests.cs
+++ b/src/GxMcp.Gateway.Tests/E2ELiveSmokeTests.cs
@@ -45,6 +45,31 @@ namespace GxMcp.Gateway.Tests
 
         public Task DisposeAsync() => Task.CompletedTask;
 
+        private async Task RequireSdkTeamDevelopmentAsync()
+        {
+            var response = await _h.CallToolAsync("genexus_gxserver", new JObject
+            {
+                ["action"] = "status"
+            });
+            Assert.False(
+                LiveGatewayHarness.IsToolError(response),
+                "Team Development status read failed: " + response.ToString(Newtonsoft.Json.Formatting.None));
+
+            var payload = LiveGatewayHarness.ParseToolPayload(response);
+            Assert.NotNull(payload);
+            var result = payload!["result"] as JObject ?? payload;
+            Assert.Equal("sdk:ITeamDevClientService", result["source"]?.ToString());
+
+            bool? connected = result["connected"]?.ToObject<bool?>();
+            if (connected == false)
+            {
+                throw SkipException.ForSkip(
+                    "The configured live KB is not linked to GeneXus Team Development; " +
+                    "set GXMCP_TEST_KB to a linked disposable KB to run this regression.");
+            }
+            Assert.True(connected == true, "Team Development status did not return a connected boolean.");
+        }
+
         private async Task<HashSet<string>> ReadTeamDevelopmentPendingNamesAsync()
         {
             var response = await _h.CallToolAsync("genexus_gxserver", new JObject
@@ -69,6 +94,34 @@ namespace GxMcp.Gateway.Tests
                     .Select(item => item["name"]?.ToString())
                     .Where(name => !string.IsNullOrWhiteSpace(name)),
                 StringComparer.OrdinalIgnoreCase);
+        }
+
+        private async Task AssertObjectsDeletedAsync(params string[] names)
+        {
+            var failures = new List<string>();
+            for (int i = names.Length - 1; i >= 0; i--)
+            {
+                try
+                {
+                    var response = await _h.CallToolAsync("genexus_delete_object", new JObject
+                    {
+                        ["name"] = names[i],
+                        ["confirm"] = true
+                    });
+                    if (LiveGatewayHarness.IsToolError(response))
+                    {
+                        failures.Add(names[i] + ": " + response.ToString(Newtonsoft.Json.Formatting.None));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(names[i] + ": " + ex.Message);
+                }
+            }
+
+            Assert.True(
+                failures.Count == 0,
+                "Team Development cleanup failed: " + string.Join(" | ", failures));
         }
 
         [LiveKbFact]
@@ -531,24 +584,12 @@ namespace GxMcp.Gateway.Tests
         [LiveKbFact]
         public async Task TeamDevelopmentPendingList_PreservesEarlierMcpWriteAfterLaterWrite()
         {
-            var statusResponse = await _h.CallToolAsync("genexus_gxserver", new JObject
-            {
-                ["action"] = "status"
-            });
-            var statusPayload = LiveGatewayHarness.ParseToolPayload(statusResponse);
-            Assert.NotNull(statusPayload);
-            var status = statusPayload!["result"] as JObject ?? statusPayload;
-            if (status["connected"]?.ToObject<bool?>() != true ||
-                !string.Equals(status["source"]?.ToString(), "sdk:ITeamDevClientService", StringComparison.Ordinal))
-            {
-                throw SkipException.ForSkip(
-                    "The configured live KB does not expose the SDK Team Development service; " +
-                    "set GXMCP_TEST_KB to a linked disposable KB to run this regression.");
-            }
+            await RequireSdkTeamDevelopmentAsync();
 
             string stamp = Guid.NewGuid().ToString("N").Substring(0, 8);
             string first = "TestTeamDevA" + stamp;
             string second = "TestTeamDevB" + stamp;
+            var created = new List<string>();
 
             try
             {
@@ -561,6 +602,7 @@ namespace GxMcp.Gateway.Tests
                 Assert.False(
                     LiveGatewayHarness.IsToolError(createFirst),
                     "create failed for " + first + ": " + createFirst.ToString(Newtonsoft.Json.Formatting.None));
+                created.Add(first);
 
                 var firstEdit = await _h.CallToolAsync("genexus_edit", new JObject
                 {
@@ -591,6 +633,7 @@ namespace GxMcp.Gateway.Tests
                 Assert.False(
                     LiveGatewayHarness.IsToolError(createSecond),
                     "create failed for " + second + ": " + createSecond.ToString(Newtonsoft.Json.Formatting.None));
+                created.Add(second);
 
                 var secondEdit = await _h.CallToolAsync("genexus_edit", new JObject
                 {
@@ -614,13 +657,67 @@ namespace GxMcp.Gateway.Tests
             }
             finally
             {
-                try
+                await AssertObjectsDeletedAsync(created.ToArray());
+            }
+        }
+
+        [LiveKbFact]
+        public async Task TeamDevelopmentPendingList_PreservesIdeChangeAfterMcpWrite()
+        {
+            string idePendingName = Environment.GetEnvironmentVariable("GXMCP_TEAMDEV_PENDING_NAME");
+            if (string.IsNullOrWhiteSpace(idePendingName))
+            {
+                throw SkipException.ForSkip(
+                    "Set GXMCP_TEAMDEV_PENDING_NAME to a pre-seeded IDE-changed object to run this regression.");
+            }
+
+            await RequireSdkTeamDevelopmentAsync();
+            var before = await ReadTeamDevelopmentPendingNamesAsync();
+            Assert.Contains(
+                idePendingName,
+                before);
+
+            string mcpName = "TestTeamDevMcp" + Guid.NewGuid().ToString("N").Substring(0, 8);
+            bool created = false;
+            try
+            {
+                var create = await _h.CallToolAsync("genexus_create", new JObject
                 {
-                    await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = second, ["confirm"] = true });
-                }
-                finally
+                    ["action"] = "object",
+                    ["type"] = "Procedure",
+                    ["name"] = mcpName
+                });
+                Assert.False(
+                    LiveGatewayHarness.IsToolError(create),
+                    "create failed for " + mcpName + ": " + create.ToString(Newtonsoft.Json.Formatting.None));
+                created = true;
+
+                var afterCreate = await ReadTeamDevelopmentPendingNamesAsync();
+                Assert.Contains(
+                    idePendingName,
+                    afterCreate);
+
+                var edit = await _h.CallToolAsync("genexus_edit", new JObject
                 {
-                    await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = first, ["confirm"] = true });
+                    ["name"] = mcpName,
+                    ["part"] = "Source",
+                    ["mode"] = "full",
+                    ["content"] = "&TeamDevMcp = 1",
+                    ["autoDeclareVariables"] = true
+                });
+                Assert.False(
+                    LiveGatewayHarness.IsToolError(edit),
+                    "edit failed for " + mcpName + ": " + edit.ToString(Newtonsoft.Json.Formatting.None));
+
+                var afterEdit = await ReadTeamDevelopmentPendingNamesAsync();
+                Assert.Contains(idePendingName, afterEdit);
+                Assert.Contains(mcpName, afterEdit);
+            }
+            finally
+            {
+                if (created)
+                {
+                    await AssertObjectsDeletedAsync(mcpName);
                 }
             }
         }

--- a/src/GxMcp.Gateway.Tests/E2ELiveSmokeTests.cs
+++ b/src/GxMcp.Gateway.Tests/E2ELiveSmokeTests.cs
@@ -664,7 +664,7 @@ namespace GxMcp.Gateway.Tests
         [LiveKbFact]
         public async Task TeamDevelopmentPendingList_PreservesIdeChangeAfterMcpWrite()
         {
-            string idePendingName = Environment.GetEnvironmentVariable("GXMCP_TEAMDEV_PENDING_NAME");
+            string? idePendingName = Environment.GetEnvironmentVariable("GXMCP_TEAMDEV_PENDING_NAME");
             if (string.IsNullOrWhiteSpace(idePendingName))
             {
                 throw SkipException.ForSkip(

--- a/src/GxMcp.Gateway.Tests/E2ELiveSmokeTests.cs
+++ b/src/GxMcp.Gateway.Tests/E2ELiveSmokeTests.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace GxMcp.Gateway.Tests
 {
@@ -42,6 +44,32 @@ namespace GxMcp.Gateway.Tests
         }
 
         public Task DisposeAsync() => Task.CompletedTask;
+
+        private async Task<HashSet<string>> ReadTeamDevelopmentPendingNamesAsync()
+        {
+            var response = await _h.CallToolAsync("genexus_gxserver", new JObject
+            {
+                ["action"] = "pending",
+                ["limit"] = 100
+            });
+            Assert.False(
+                LiveGatewayHarness.IsToolError(response),
+                "Team Development pending read failed: " + response.ToString(Newtonsoft.Json.Formatting.None));
+
+            var payload = LiveGatewayHarness.ParseToolPayload(response);
+            Assert.NotNull(payload);
+            var result = payload!["result"] as JObject ?? payload;
+            Assert.Equal("sdk:ITeamDevClientService", result["source"]?.ToString());
+
+            var objects = result["objects"] as JArray;
+            Assert.NotNull(objects);
+            return new HashSet<string>(
+                objects!
+                    .OfType<JObject>()
+                    .Select(item => item["name"]?.ToString())
+                    .Where(name => !string.IsNullOrWhiteSpace(name)),
+                StringComparer.OrdinalIgnoreCase);
+        }
 
         [LiveKbFact]
         public async Task Whoami_BaselineUnder500ms_AndCarriesPlaybooks()
@@ -497,6 +525,94 @@ namespace GxMcp.Gateway.Tests
             {
                 if (File.Exists(tempXpz)) File.Delete(tempXpz);
                 await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = proc, ["confirm"] = true });
+            }
+        }
+
+        [LiveKbFact]
+        public async Task TeamDevelopmentPendingList_PreservesEarlierMcpWriteAfterLaterWrite()
+        {
+            var statusResponse = await _h.CallToolAsync("genexus_gxserver", new JObject
+            {
+                ["action"] = "status"
+            });
+            var statusPayload = LiveGatewayHarness.ParseToolPayload(statusResponse);
+            Assert.NotNull(statusPayload);
+            var status = statusPayload!["result"] as JObject ?? statusPayload;
+            if (status["connected"]?.ToObject<bool?>() != true)
+            {
+                throw SkipException.ForSkip(
+                    "The configured live KB is not linked to GeneXus Team Development; " +
+                    "set GXMCP_TEST_KB to a linked disposable KB to run this regression.");
+            }
+
+            string tickHex = DateTime.UtcNow.Ticks.ToString("X");
+            string stamp = tickHex.Substring(tickHex.Length - 8).ToLowerInvariant();
+            string first = "TestTeamDevA" + stamp;
+            string second = "TestTeamDevB" + stamp;
+
+            try
+            {
+                var createFirst = await _h.CallToolAsync("genexus_create", new JObject
+                {
+                    ["action"] = "object",
+                    ["type"] = "Procedure",
+                    ["name"] = first
+                });
+                Assert.False(
+                    LiveGatewayHarness.IsToolError(createFirst),
+                    "create failed for " + first + ": " + createFirst.ToString(Newtonsoft.Json.Formatting.None));
+
+                var firstEdit = await _h.CallToolAsync("genexus_edit", new JObject
+                {
+                    ["name"] = first,
+                    ["part"] = "Source",
+                    ["mode"] = "full",
+                    ["content"] = "&TeamDevFirst = 1",
+                    ["autoDeclareVariables"] = true
+                });
+                Assert.False(
+                    LiveGatewayHarness.IsToolError(firstEdit),
+                    "first edit failed: " + firstEdit.ToString(Newtonsoft.Json.Formatting.None));
+
+                var afterFirst = await ReadTeamDevelopmentPendingNamesAsync();
+                Assert.True(
+                    afterFirst.Contains(first),
+                    "The first MCP write must appear in the Team Development pending list.");
+
+                var createSecond = await _h.CallToolAsync("genexus_create", new JObject
+                {
+                    ["action"] = "object",
+                    ["type"] = "Procedure",
+                    ["name"] = second
+                });
+                Assert.False(
+                    LiveGatewayHarness.IsToolError(createSecond),
+                    "create failed for " + second + ": " + createSecond.ToString(Newtonsoft.Json.Formatting.None));
+
+                var secondEdit = await _h.CallToolAsync("genexus_edit", new JObject
+                {
+                    ["name"] = second,
+                    ["part"] = "Source",
+                    ["mode"] = "full",
+                    ["content"] = "&TeamDevSecond = 1",
+                    ["autoDeclareVariables"] = true
+                });
+                Assert.False(
+                    LiveGatewayHarness.IsToolError(secondEdit),
+                    "second edit failed: " + secondEdit.ToString(Newtonsoft.Json.Formatting.None));
+
+                var afterSecond = await ReadTeamDevelopmentPendingNamesAsync();
+                Assert.True(
+                    afterSecond.Contains(first),
+                    "A later MCP write must not clear the earlier pending object.");
+                Assert.True(
+                    afterSecond.Contains(second),
+                    "The later MCP write must appear in the Team Development pending list.");
+            }
+            finally
+            {
+                await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = second, ["confirm"] = true });
+                await _h.CallToolAsync("genexus_delete_object", new JObject { ["name"] = first, ["confirm"] = true });
             }
         }
     }

--- a/src/GxMcp.Worker.Tests/TeamDevBaselineGuardTests.cs
+++ b/src/GxMcp.Worker.Tests/TeamDevBaselineGuardTests.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -22,26 +25,144 @@ namespace GxMcp.Worker.Tests
     // LastObjectsVersionDate to make the IDE reload the worker's writes.
     public class TeamDevBaselineGuardTests
     {
-        private static string[] CodeLines(string fileName)
+        private sealed class SourceLine
         {
-            string path = Path.GetFullPath(Path.Combine(
-                TestFixtures.FindRepoRoot(), "src", "GxMcp.Worker", "Services", fileName));
-            Assert.True(File.Exists(path), fileName + " must exist at: " + path);
+            public string FileName { get; set; }
+            public int Number { get; set; }
+            public string Text { get; set; }
+        }
 
-            // Comments legitimately name LastCommitDate to explain why it is
-            // left alone; only real code counts.
-            return File.ReadAllLines(path)
-                .Where(l => !l.TrimStart().StartsWith("//"))
+        private static string ServicesDirectory
+        {
+            get
+            {
+                return Path.GetFullPath(Path.Combine(
+                    TestFixtures.FindRepoRoot(), "src", "GxMcp.Worker", "Services"));
+            }
+        }
+
+        private static SourceLine[] CodeLines()
+        {
+            Assert.True(Directory.Exists(ServicesDirectory),
+                "WriteService source directory must exist at: " + ServicesDirectory);
+
+            return Directory.GetFiles(ServicesDirectory, "WriteService*.cs")
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .SelectMany(ReadCodeLines)
                 .ToArray();
         }
 
-        [Fact]
-        public void WriteService_NeverStamps_ModelLastCommitDate()
+        private static IEnumerable<SourceLine> ReadCodeLines(string path)
         {
-            var offenders = CodeLines("WriteService.cs")
-                .Select((line, i) => new { line, n = i + 1 })
-                .Where(x => Regex.IsMatch(x.line, @"LastCommitDate\s*="))
-                .Select(x => "line " + x.n + ": " + x.line.Trim())
+            bool inBlockComment = false;
+            string[] lines = File.ReadAllLines(path);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                yield return new SourceLine
+                {
+                    FileName = Path.GetFileName(path),
+                    Number = i + 1,
+                    Text = RemoveComments(lines[i], ref inBlockComment)
+                };
+            }
+        }
+
+        private static string RemoveComments(string line, ref bool inBlockComment)
+        {
+            var code = new StringBuilder();
+            bool inString = false;
+            bool escaped = false;
+            char delimiter = '\0';
+
+            for (int i = 0; i < line.Length; i++)
+            {
+                char current = line[i];
+                char next = i + 1 < line.Length ? line[i + 1] : '\0';
+
+                if (inBlockComment)
+                {
+                    if (current == '*' && next == '/')
+                    {
+                        inBlockComment = false;
+                        i++;
+                    }
+                    continue;
+                }
+
+                if (!inString && current == '/' && next == '/') break;
+                if (!inString && current == '/' && next == '*')
+                {
+                    inBlockComment = true;
+                    i++;
+                    continue;
+                }
+
+                code.Append(current);
+                if (inString)
+                {
+                    if (escaped)
+                    {
+                        escaped = false;
+                    }
+                    else if (current == '\\')
+                    {
+                        escaped = true;
+                    }
+                    else if (current == delimiter)
+                    {
+                        inString = false;
+                    }
+                }
+                else if (current == '"' || current == '\'')
+                {
+                    inString = true;
+                    delimiter = current;
+                }
+            }
+
+            return code.ToString();
+        }
+
+        private static string MethodBody(string source, string methodName)
+        {
+            Match declaration = Regex.Match(
+                source,
+                @"(?m)^\s*(?:private|internal|public|protected)\b[^\r\n]*\b" +
+                    Regex.Escape(methodName) + @"\s*\(");
+            Assert.True(declaration.Success, methodName + " must exist in WriteService.cs");
+
+            int openBrace = source.IndexOf('{', declaration.Index + declaration.Length);
+            Assert.True(openBrace >= 0, methodName + " must have a body");
+
+            int depth = 0;
+            for (int i = openBrace; i < source.Length; i++)
+            {
+                if (source[i] == '{') depth++;
+                if (source[i] != '}') continue;
+                depth--;
+                if (depth == 0)
+                    return source.Substring(openBrace + 1, i - openBrace - 1);
+            }
+
+            Assert.Fail(methodName + " has an unterminated body");
+            return string.Empty;
+        }
+
+        private static string CodeOnly(string source)
+        {
+            bool inBlockComment = false;
+            return string.Join(
+                Environment.NewLine,
+                source.Replace("\r\n", "\n").Split('\n')
+                    .Select(line => RemoveComments(line, ref inBlockComment)));
+        }
+
+        [Fact]
+        public void WriteServicePartials_NeverStamp_ModelLastCommitDate()
+        {
+            var offenders = CodeLines()
+                .Where(x => Regex.IsMatch(x.Text, @"\bLastCommitDate\s*="))
+                .Select(x => x.FileName + ":" + x.Number + ": " + x.Text.Trim())
                 .ToArray();
 
             Assert.True(offenders.Length == 0,
@@ -52,13 +173,18 @@ namespace GxMcp.Worker.Tests
         }
 
         [Fact]
-        public void WriteService_StillStamps_ModelLastObjectsVersionDate()
+        public void WriteService_Stamps_ModelLastObjectsVersionDate_InEachRevisionPath()
         {
-            // The #128 intent must survive the guard above: the IDE has to be
-            // told the model's objects changed, or it serves stale objects.
-            Assert.Contains(
-                CodeLines("WriteService.cs"),
-                l => Regex.IsMatch(l, @"LastObjectsVersionDate\s*="));
+            string path = Path.Combine(ServicesDirectory, "WriteService.cs");
+            Assert.True(File.Exists(path), "WriteService.cs must exist at: " + path);
+            string source = File.ReadAllText(path);
+
+            Assert.Matches(
+                @"\bLastObjectsVersionDate\s*=",
+                CodeOnly(MethodBody(source, "FlushSync")));
+            Assert.Matches(
+                @"\bLastObjectsVersionDate\s*=",
+                CodeOnly(MethodBody(source, "StampObjectRevisionDates")));
         }
     }
 }

--- a/src/GxMcp.Worker.Tests/TeamDevBaselineGuardTests.cs
+++ b/src/GxMcp.Worker.Tests/TeamDevBaselineGuardTests.cs
@@ -1,0 +1,64 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace GxMcp.Worker.Tests
+{
+    // Regression guard for the Team Development pending list.
+    //
+    // KBModel.LastCommitDate is the "everything up to this instant is already
+    // committed" baseline that ITeamDevClientService.GetLocalChanges(model)
+    // measures against — the same list surfaced by genexus_gxserver
+    // action=pending and by the IDE's Team Dev > Commit tab. Stamping it to
+    // UtcNow after a write tells Team Development that nothing is pending, and
+    // because it lives on the MODEL it wipes the entry for every object in the
+    // KB, including objects the worker never touched.
+    //
+    // Measured 2026-09-08 against v2.56.0: the IDE marked one object
+    // (pending count = 1); a single genexus_edit on a DIFFERENT object dropped
+    // the count to 0. Introduced by 4f7cc9c "IDE concurrency detection, sync
+    // flushing, and revision stamping (#128)", which needs only
+    // LastObjectsVersionDate to make the IDE reload the worker's writes.
+    public class TeamDevBaselineGuardTests
+    {
+        private static string[] CodeLines(string fileName)
+        {
+            string path = Path.GetFullPath(Path.Combine(
+                TestFixtures.FindRepoRoot(), "src", "GxMcp.Worker", "Services", fileName));
+            Assert.True(File.Exists(path), fileName + " must exist at: " + path);
+
+            // Comments legitimately name LastCommitDate to explain why it is
+            // left alone; only real code counts.
+            return File.ReadAllLines(path)
+                .Where(l => !l.TrimStart().StartsWith("//"))
+                .ToArray();
+        }
+
+        [Fact]
+        public void WriteService_NeverStamps_ModelLastCommitDate()
+        {
+            var offenders = CodeLines("WriteService.cs")
+                .Select((line, i) => new { line, n = i + 1 })
+                .Where(x => Regex.IsMatch(x.line, @"LastCommitDate\s*="))
+                .Select(x => "line " + x.n + ": " + x.line.Trim())
+                .ToArray();
+
+            Assert.True(offenders.Length == 0,
+                "Assigning KBModel.LastCommitDate moves the Team Development commit baseline and " +
+                "empties the pending-commit list for every object in the KB. Stamp " +
+                "LastObjectsVersionDate instead — that is what makes the IDE notice the worker's " +
+                "writes. Offending lines:\n" + string.Join("\n", offenders));
+        }
+
+        [Fact]
+        public void WriteService_StillStamps_ModelLastObjectsVersionDate()
+        {
+            // The #128 intent must survive the guard above: the IDE has to be
+            // told the model's objects changed, or it serves stale objects.
+            Assert.Contains(
+                CodeLines("WriteService.cs"),
+                l => Regex.IsMatch(l, @"LastObjectsVersionDate\s*="));
+        }
+    }
+}

--- a/src/GxMcp.Worker/Services/WriteService.cs
+++ b/src/GxMcp.Worker/Services/WriteService.cs
@@ -51,9 +51,16 @@ namespace GxMcp.Worker.Services
                         try
                         {
                             var now = DateTime.UtcNow;
-                            model.LastCommitDate = now;
+                            // Do NOT stamp model.LastCommitDate here. Team Development derives its
+                            // pending-commit list from it: ITeamDevClientService.GetLocalChanges(model)
+                            // treats it as the "everything up to this instant is already committed"
+                            // baseline. Moving it to UtcNow after every write silently empties the
+                            // IDE's Team Dev > Commit list for EVERY object in the model, including
+                            // objects this worker never touched. LastObjectsVersionDate alone is what
+                            // makes the IDE notice the worker's writes and reload, which is what
+                            // #128 was after.
                             model.LastObjectsVersionDate = now;
-                            Logger.Info("[FLUSH-SYNC] Model revision dates updated.");
+                            Logger.Info("[FLUSH-SYNC] Model objects-version date updated (LastCommitDate left untouched to preserve Team Development local changes).");
                         }
                         catch (Exception ex)
                         {
@@ -82,7 +89,8 @@ namespace GxMcp.Worker.Services
                 try { obj.SaveVersionIndependentDate(310, 0, now); } catch { }
                 if (model != null)
                 {
-                    try { model.LastCommitDate = now; } catch { }
+                    // LastCommitDate deliberately not stamped — see FlushSync above: it is the
+                    // Team Development commit baseline, and stamping it wipes the pending list.
                     try { model.LastObjectsVersionDate = now; } catch { }
                 }
             }


### PR DESCRIPTION
## Problem

`WriteService` stamps `model.LastCommitDate = DateTime.UtcNow` after every object save — in `FlushSync()` and again in `StampObjectRevisionDates()`.

`LastCommitDate` is the baseline Team Development uses: `ITeamDevClientService.GetLocalChanges(model)` — the same API `genexus_gxserver action=pending` reads through `GxServerSyncService.EnumLocalChanges` — treats everything older than that date as already committed. Moving it to `UtcNow` on each write tells Team Development "everything was just committed", so the IDE's **Team Development > Commit** list goes empty.

Because it is a **model**-level property, it drops the pending mark of *every* object in the KB, including objects the worker never touched — e.g. work a developer marked in the IDE for a different task.

Introduced in 4f7cc9c ("fix(worker): IDE concurrency detection, sync flushing, and revision stamping", #128). Present from v2.56.0 through v3.0.2.

## Reproduction (GXserver-linked KB, IDE open on the same KB)

```
1. change + save object A in the IDE
   genexus_gxserver action=pending  -> count: 1   (object A)
2. genexus_edit on object B (part=Documentation) — a DIFFERENT object
   genexus_gxserver action=pending  -> count: 0   (list empty)
```

`pending` does see IDE marks (it counted 1), so the read side is fine — the write is what clears the list.

## Fix

Drop the two `LastCommitDate` assignments, keep `LastObjectsVersionDate`. `LastObjectsVersionDate` alone is what makes the IDE notice the worker's writes and reload, which is what #128 was after; `LastCommitDate` came along for the ride and carries the Team Development semantics.

## Verification

Same KB, worker rebuilt with the patch:

```
pending -> 1 (object A, marked in the IDE)
genexus_edit on object B  -> pending -> 2   (A survived, B now listed)
genexus_edit on object B  -> pending -> 2   (stable across a second write)
```

Bonus: the object written over MCP now shows up in the commit list **on its own**, which it never did before. The two symptoms people reported ("MCP edits don't get marked for commit" and "MCP edits wipe the pending list") were the same bug — the reset baseline was hiding the write's own mark too.

Test suite on the patched tree:

- `GxMcp.Worker.Tests` (net48): 2348 passed, 0 failed, 4 skipped
- `GxMcp.Gateway.Tests` (net10.0): 1427 passed, 0 failed, 10 skipped

`TeamDevBaselineGuardTests` (following the repo's `*GuardTests` convention) covers both directions: reintroducing the assignment fails the test and names the offending line; `LastObjectsVersionDate` stamping is asserted to stay.
