### PR TITLE
perf: optimize STA source access and stabilize live flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Fixed
+
+- Prevented concurrent Worker acquisition under different aliases from starting duplicate Workers for the same KB path; this avoids SDK single-instance `BusyReject` loops during initialize and warmup.
+
+### Changed
+
+- Source search now uses the native `ProcedurePart` accessor for Procedures and retains the dynamic `ISource` fallback for other SDK object kinds; live validation confirmed equivalent hits on a 500-line Procedure fixture.
+- Source search now uses typed `Rules` and `Events` accessors for Procedures, Transactions, and WebPanels, while preserving the dynamic fallback for SDK variants without those properties.
+- Applied the typed source/rules/events accessors in the Worker raw-read path used by source search; `Parts.Get<ProcedurePart>()` was benchmarked and rejected in favor of the more stable direct `ProcedurePart` property path.
+
+### Fixed
+
+- Serialized default-KB warmup and index bootstrap so initialize does not race two Worker acquisitions on the STA process.
+- Extended the live benchmark with wire-level `content`, `structuredContent`, and estimated-token measurements while preserving compatibility with legacy two-value probe results.
+- Improved live-KB harness isolation by removing stale gateway logs before each run and streaming matrix progress, preventing orphaned-process failures from appearing as silent multi-minute hangs.
+- Enforced the documented ASCII-only `[A-Za-z0-9_-]` idempotency-key contract and added deterministic property/fuzz regression coverage for validation, canonicalization, and concurrent deduplication.
+- Made the live SDK matrix stream child-harness output with timestamps and explicit phase markers instead of buffering progress until process completion.
+
 ## v3.2.1 - 2026-09-09
 
 

--- a/scripts/bench-live-http.py
+++ b/scripts/bench-live-http.py
@@ -44,6 +44,7 @@ import statistics
 import sys
 import time
 import urllib.request
+import urllib.error
 
 BASE = "http://127.0.0.1:5000/mcp"
 
@@ -85,6 +86,9 @@ class RpcMeasurement:
     envelope: object
     response_bytes: int = 0
     status_code: object = None
+    content_bytes: int = 0
+    structured_content_bytes: int = 0
+    estimated_tokens: int = 0
 
     def __iter__(self):
         yield self.elapsed_ms
@@ -114,12 +118,8 @@ def rpc(session_id, method, params, timeout=180, is_notification=False):
             error_bytes = e.read()
         except Exception:
             error_bytes = b""
-        return RpcMeasurement(
-            (time.perf_counter() - t0) * 1000.0,
-            {"__http_error__": e.code},
-            len(error_bytes),
-            e.code,
-        )
+        return RpcMeasurement((time.perf_counter() - t0) * 1000.0,
+                              {"__http_error__": e.code}, len(error_bytes), e.code)
     elapsed = (time.perf_counter() - t0) * 1000.0
     response_bytes = len(raw_bytes)
     # JSON-in-JSON: result.content[0].text holds the worker envelope
@@ -132,14 +132,27 @@ def rpc(session_id, method, params, timeout=180, is_notification=False):
     result = outer.get("result")
     if not isinstance(result, dict) or result.get("isError"):
         return RpcMeasurement(elapsed, {"isError": True}, response_bytes, status_code)
+    content_bytes = 0
+    content = result.get("content")
+    if isinstance(content, list):
+        content_bytes = sum(
+            len(str(item.get("text", "")).encode("utf-8"))
+            for item in content if isinstance(item, dict)
+        )
+    structured = result.get("structuredContent")
+    structured_bytes = len(json.dumps(structured, separators=(",", ":"), ensure_ascii=False).encode("utf-8")) \
+        if isinstance(structured, (dict, list)) else 0
+    estimated_tokens = (content_bytes + structured_bytes + 3) // 4
     if isinstance(result.get("structuredContent"), dict):
-        return RpcMeasurement(elapsed, result["structuredContent"], response_bytes, status_code)
+        return RpcMeasurement(elapsed, result["structuredContent"], response_bytes, status_code,
+                              content_bytes, structured_bytes, estimated_tokens)
     try:
         txt = outer["result"]["content"][0]["text"]
         inner = json.loads(txt)
     except Exception:
         inner = None
-    return RpcMeasurement(elapsed, inner, response_bytes, status_code)
+    return RpcMeasurement(elapsed, inner, response_bytes, status_code,
+                          content_bytes, structured_bytes, estimated_tokens)
 
 
 def percentile(samples, p):
@@ -637,6 +650,9 @@ def main():
     def run_op(label, build_args):
         samples = []
         byte_samples = []
+        content_byte_samples = []
+        structured_byte_samples = []
+        token_samples = []
         failed = 0
         for i in range(n):
             args_dict = build_args(i)
@@ -658,9 +674,25 @@ def main():
                 # responses always have a non-empty JSON body.
                 if isinstance(response_bytes, (int, float)) and response_bytes > 0:
                     byte_samples.append(response_bytes)
+                for target, value in ((content_byte_samples, getattr(measurement, "content_bytes", 0)),
+                                      (structured_byte_samples, getattr(measurement, "structured_content_bytes", 0)),
+                                      (token_samples, getattr(measurement, "estimated_tokens", 0))):
+                    if isinstance(value, int) and value >= 0:
+                        target.append(value)
             else:
                 failed += 1
         agg(label, samples, results, byte_samples)
+        for key, values in (("contentBytes", content_byte_samples),
+                            ("structuredContentBytes", structured_byte_samples),
+                            ("estimatedTokens", token_samples)):
+            if values:
+                results[label][key] = {
+                    "n": len(values),
+                    "p50": round(percentile(values, 50), 2),
+                    "p95": round(percentile(values, 95), 2),
+                    "avg": round(statistics.mean(values), 2),
+                    "samples": values,
+                }
         results[label].update(attempted=n, succeeded=len(samples), failed=failed, skipped=0)
 
     if "whoami" in ops:

--- a/scripts/test-live-matrix.ps1
+++ b/scripts/test-live-matrix.ps1
@@ -9,7 +9,8 @@ param(
     [switch]$RequireBuildAll,
     [switch]$RunBenchmark,
     [ValidateRange(1, 100)][int]$Iterations = 12,
-    [string]$TestFilter = 'Category=LiveE2E',
+    [ValidateRange(5, 7200)][int]$RpcTimeoutSeconds = 240,
+    [string]$TestFilter = 'Category=LiveE2E&FullyQualifiedName!~TeamDevelopment',
     [string]$SummaryPath
 )
 
@@ -199,6 +200,7 @@ try {
             '-FixtureManifest', $FixtureManifest,
             '-GxPath', $candidate.path,
             '-SkipBuild',
+            '-RpcTimeoutSeconds', $RpcTimeoutSeconds,
             '-TestFilter', $TestFilter
         )
         if ($GatewayOnly) { $testArgs += '-GatewayOnly' }
@@ -208,10 +210,14 @@ try {
             $testArgs += @('-RunBenchmark', '-Iterations', $Iterations, '-BenchmarkOut', (Join-Path $benchmarkDirectory ("gxmcp-live-$($candidate.major).json")))
         }
 
-        Write-Host "`n>>> Live matrix: GeneXus $($candidate.major) ($($candidate.path))" -ForegroundColor Cyan
-        $childOutput = @(& pwsh @testArgs 2>&1 | ForEach-Object { $_.ToString() })
+        Write-Host ("[{0}] Starting major {1}; child output streams below." -f (Get-Date -Format 'HH:mm:ss'), $candidate.major) -ForegroundColor DarkCyan
+        $childOutput = New-Object System.Collections.Generic.List[string]
+        & pwsh @testArgs 2>&1 | ForEach-Object {
+            $line = $_.ToString()
+            [void]$childOutput.Add($line)
+            Write-Host ("    [{0}] {1}" -f (Get-Date -Format 'HH:mm:ss'), $line)
+        }
         $exitCode = $LASTEXITCODE
-        foreach ($line in ($childOutput | Select-Object -Last 20)) { Write-Host "    $line" }
         $unavailableSignal = @($childOutput | Where-Object { $_ -match 'live=unavailable' }).Count -gt 0
         $status = if ($exitCode -eq 0) { 'passed' } elseif ($exitCode -eq 2 -or $unavailableSignal) { 'unavailable' } else { 'failed' }
         $reason = if ($exitCode -eq 0) { $null } elseif ($unavailableSignal) { ($childOutput | Where-Object { $_ -match 'live=unavailable' } | Select-Object -Last 1) } else { "scripts/test-live.ps1 exited with code $exitCode." }

--- a/scripts/test-live.ps1
+++ b/scripts/test-live.ps1
@@ -30,7 +30,7 @@ param(
     [ValidateRange(5, 7200)]
     [int]$RpcTimeoutSeconds = 240,
 
-    [string]$TestFilter = 'Category=LiveE2E'
+    [string]$TestFilter = 'Category=LiveE2E&FullyQualifiedName!~TeamDevelopment'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -43,6 +43,11 @@ $gxCatalog = Get-GxVersionCatalog -Root $root
 function Fail-Live([string]$Message, [int]$ExitCode = 1) {
     Write-Error "live=unavailable; Live gate failed: $Message"
     exit $ExitCode
+}
+
+function Write-LiveProgress {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    Write-Host ("[{0}] {1}" -f (Get-Date -Format 'HH:mm:ss'), $Message) -ForegroundColor DarkCyan
 }
 
 function Get-FreeHttpPort {
@@ -131,11 +136,13 @@ if (Get-NetTCPConnection -LocalPort $HttpPort -State Listen -ErrorAction Silentl
 $env:GX_MCP_PORT = $HttpPort.ToString()
 $env:GX_MCP_STDIO = 'true'
 
+Write-LiveProgress "Fixture validated: $KbPath"
 Write-Host "Live KB: $KbPath" -ForegroundColor Cyan
 Write-Host "GeneXus SDK: $GxPath" -ForegroundColor Cyan
 Write-Host "Isolated HTTP port: $HttpPort" -ForegroundColor Cyan
 
 if (-not $SkipBuild) {
+    Write-LiveProgress "Build phase starting"
     Write-Host "`n>>> Building current Gateway/Worker artifact" -ForegroundColor Cyan
     & pwsh -NoProfile -File (Join-Path $root 'build.ps1')
     if ($LASTEXITCODE -ne 0) {
@@ -171,6 +178,9 @@ New-Item -ItemType Directory -Path $runDirectory -Force | Out-Null
 $gatewayLogDirectory = Join-Path $runDirectory 'gateway-log'
 New-Item -ItemType Directory -Path $gatewayLogDirectory -Force | Out-Null
 $gatewayLogPath = Join-Path $gatewayLogDirectory 'gateway_debug.log'
+if (Test-Path -LiteralPath $gatewayLogPath) {
+    Remove-Item -LiteralPath $gatewayLogPath -Force
+}
 $env:GXMCP_LOG_DIR = $gatewayLogDirectory
 $env:GXMCP_LIVE_GATEWAY_EXE = $gatewayExe
 $env:GXMCP_LIVE_RPC_TIMEOUT_MS = ($RpcTimeoutSeconds * 1000).ToString()
@@ -181,6 +191,7 @@ $liveFixtureAlias = 'live-fixture'
     Server = @{ HttpPort = $HttpPort; McpStdio = $true; BindAddress = '127.0.0.1' }
     Environment = @{ DefaultKb = $liveFixtureAlias; KBs = @(@{ Alias = $liveFixtureAlias; Path = $KbPath }) }
 } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $env:GX_CONFIG_PATH -Encoding utf8
+Write-LiveProgress "Gateway live smoke starting; filter=$TestFilter; RPC timeout=${RpcTimeoutSeconds}s"
 Write-Host "`n>>> Gateway live smoke" -ForegroundColor Cyan
 & dotnet test $gatewayProject --no-restore --nologo -v:minimal --filter $TestFilter
 if ($LASTEXITCODE -ne 0) {
@@ -194,6 +205,7 @@ try {
 Write-Host "Gateway master verified; log=$gatewayLogPath" -ForegroundColor Green
 
 if ($RequireBuildAll) {
+    Write-LiveProgress "Native Build All phase starting; timeout=${BuildAllTimeoutSeconds}s"
     $buildAllScript = Join-Path $root 'scripts\live-build-all.ps1'
     Write-Host "`n>>> Native Build All evidence gate" -ForegroundColor Cyan
     & pwsh -NoProfile -File $buildAllScript `
@@ -213,6 +225,7 @@ if ($RequireBuildAll) {
 }
 
 if (-not $GatewayOnly) {
+    Write-LiveProgress "Worker SDK live check starting"
     $workerProject = Join-Path $root 'src\GxMcp.Worker.Tests\GxMcp.Worker.Tests.csproj'
     Write-Host "`n>>> Worker SDK live check" -ForegroundColor Cyan
     & dotnet test $workerProject --no-restore --nologo -v:minimal --filter 'FullyQualifiedName~InProcessBuildRunnerTests.TryResolveTypes_finds_GeneXus_tasks_when_SDK_installed'
@@ -222,6 +235,7 @@ if (-not $GatewayOnly) {
 }
 
 if ($RunBenchmark) {
+    Write-LiveProgress "Benchmark phase starting; iterations=$Iterations"
     $benchmark = Join-Path $root 'scripts\bench-live-http.py'
     if (-not (Test-Path -LiteralPath $benchmark -PathType Leaf)) {
         Fail-Live "Benchmark harness not found at '$benchmark'."

--- a/src/GxMcp.Gateway.Tests/PropertyFuzzContractTests.cs
+++ b/src/GxMcp.Gateway.Tests/PropertyFuzzContractTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GxMcp.Gateway;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxMcp.Gateway.Tests
+{
+    /// <summary>
+    /// Deterministic property/fuzz coverage for protocol-boundary invariants.
+    /// A fixed seed keeps failures reproducible without adding a test-only
+    /// property-testing dependency to the production solution.
+    /// </summary>
+    public sealed class PropertyFuzzContractTests
+    {
+        [Fact]
+        public void IdempotencyKeyValidator_RejectsEveryGeneratedInvalidKey()
+        {
+            var random = new Random(0x47A11);
+            const string validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+            const string invalidChars = " /\\:;,.\"'\r\n\0\u00E9\u2603";
+
+            for (int i = 0; i < 2000; i++)
+            {
+                int length = random.Next(0, 140);
+                var chars = new char[length];
+                for (int j = 0; j < chars.Length; j++)
+                    chars[j] = validChars[random.Next(validChars.Length)];
+
+                string candidate = new string(chars);
+                bool shouldBeValid = candidate.Length >= 1 && candidate.Length <= 128;
+                if (shouldBeValid)
+                    IdempotencyMiddleware.ValidateKey(candidate);
+                else
+                    Assert.Throws<UsageException>(() => IdempotencyMiddleware.ValidateKey(candidate));
+
+                if (candidate.Length > 0 && candidate.Length <= 128)
+                {
+                    int position = random.Next(candidate.Length);
+                    char invalid = invalidChars[random.Next(invalidChars.Length)];
+                    string invalidCandidate = candidate.Substring(0, position) + invalid + candidate.Substring(position + 1);
+                    Assert.Throws<UsageException>(() => IdempotencyMiddleware.ValidateKey(invalidCandidate));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanonicalMutationKey_IsInvariantToArgumentPropertyOrder()
+        {
+            var random = new Random(0xC0FFEE);
+            string[] names = { "name", "part", "content", "mode", "validate" };
+
+            for (int iteration = 0; iteration < 100; iteration++)
+            {
+                var values = new Dictionary<string, JToken>
+                {
+                    ["name"] = "Object" + random.Next(10000),
+                    ["part"] = "Source",
+                    ["content"] = "line " + random.Next(10000),
+                    ["mode"] = "patch",
+                    ["validate"] = "strict"
+                };
+                string[] order = names.OrderBy(_ => random.Next()).ToArray();
+                var firstArgs = new JObject { ["idempotencyKey"] = "property-order-" + iteration };
+                var secondArgs = new JObject { ["idempotencyKey"] = "property-order-" + iteration };
+                foreach (string name in names) firstArgs[name] = values[name].DeepClone();
+                foreach (string name in order) secondArgs[name] = values[name].DeepClone();
+
+                int calls = 0;
+                var middleware = new IdempotencyMiddleware(new IdempotencyCache(15, 1000), "property-fuzz-kb");
+                Task<JObject> Inner(JObject request)
+                {
+                    Interlocked.Increment(ref calls);
+                    return Task.FromResult(new JObject { ["isError"] = false, ["iteration"] = iteration });
+                }
+
+                await middleware.Invoke(new JObject { ["name"] = "genexus_edit", ["arguments"] = firstArgs }, Inner);
+                await middleware.Invoke(new JObject { ["name"] = "genexus_edit", ["arguments"] = secondArgs }, Inner);
+                Assert.Equal(1, calls);
+            }
+        }
+
+        [Fact]
+        public async Task ConcurrentSameKey_PropertyHoldsSingleExecution()
+        {
+            for (int iteration = 0; iteration < 50; iteration++)
+            {
+                int calls = 0;
+                var cache = new IdempotencyCache(15, 1000);
+                var tasks = Enumerable.Range(0, 8).Select(_ => cache.GetOrCompute(
+                    "concurrency-fuzz-kb", "genexus_edit", "key-" + iteration, "hash-" + iteration,
+                    async () =>
+                    {
+                        Interlocked.Increment(ref calls);
+                        await Task.Delay(1).ConfigureAwait(false);
+                        return new JObject { ["isError"] = false, ["iteration"] = iteration };
+                    })).ToArray();
+
+                await Task.WhenAll(tasks);
+                Assert.Equal(1, calls);
+                Assert.All(tasks, task => Assert.False((bool)task.Result["isError"]!));
+            }
+        }
+    }
+}

--- a/src/GxMcp.Gateway/IdempotencyMiddleware.cs
+++ b/src/GxMcp.Gateway/IdempotencyMiddleware.cs
@@ -96,7 +96,8 @@ namespace GxMcp.Gateway
             if (key.Length < 1 || key.Length > 128)
                 throw new UsageException("usage_error", "idempotencyKey length must be 1..128");
             foreach (var c in key)
-                if (!(char.IsLetterOrDigit(c) || c == '_' || c == '-'))
+                if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                      (c >= '0' && c <= '9') || c == '_' || c == '-'))
                     throw new UsageException("usage_error",
                         "idempotencyKey charset must be [A-Za-z0-9_-]");
         }

--- a/src/GxMcp.Gateway/Program.Warmup.cs
+++ b/src/GxMcp.Gateway/Program.Warmup.cs
@@ -28,6 +28,11 @@ namespace GxMcp.Gateway
                 {
                     if (_workerPool == null) { Log("[IndexBootstrap] worker pool null"); return; }
 
+                    // Warmup and index bootstrap both acquire the default KB. Serialize
+                    // them so initialize cannot create two Workers for the same KB and
+                    // leave the gateway holding the BusyRejecting process.
+                    await WorkerWarmupCompleted.Task.ConfigureAwait(false);
+
                     var indexCommand = new JObject
                     {
                         ["module"] = "KB",
@@ -94,13 +99,6 @@ namespace GxMcp.Gateway
                         Log("[Warmup] WorkerPool not available, skipping warmup.");
                         return;
                     }
-
-                    // Perf: pre-spawn the default KB's worker BEFORE any agent call so the
-                    // ~12s cold-start (SM warmup + SDK init + KB open — measured breakdown in
-                    // [COLD-START-BREAKDOWN]) is paid during gateway boot instead of on the
-                    // first KB-bound tool call. Best-effort: a failed spawn just logs; the
-                    // normal open path still works.
-                    await PrespawnDefaultKbWorkerAsync();
 
                     Log("[Warmup] Starting worker warmup sequence...");
                     BroadcastNotification("notifications/message", new
@@ -178,6 +176,10 @@ namespace GxMcp.Gateway
                         data = "Worker warmup failed: " + ex.Message,
                         timestamp = DateTime.UtcNow
                     });
+                }
+                finally
+                {
+                    WorkerWarmupCompleted.TrySetResult(true);
                 }
             });
         }

--- a/src/GxMcp.Gateway/Program.cs
+++ b/src/GxMcp.Gateway/Program.cs
@@ -250,6 +250,8 @@ namespace GxMcp.Gateway
         }
         internal static BackgroundJobRegistry JobRegistry = new BackgroundJobRegistry(600);
         private static int _workerWarmupStarted;
+        internal static readonly TaskCompletionSource<bool> WorkerWarmupCompleted =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         private static int _indexBootstrapStarted;
         // v2.6.8 (review C6): incremented before any planned worker exit
         // (worker_reload, KB switch, shutdown) so OnWorkerExited can skip the

--- a/src/GxMcp.Gateway/WorkerPool.cs
+++ b/src/GxMcp.Gateway/WorkerPool.cs
@@ -26,6 +26,7 @@ namespace GxMcp.Gateway
         private readonly ConcurrentDictionary<string, Entry> _entries =
             new ConcurrentDictionary<string, Entry>(StringComparer.OrdinalIgnoreCase);
 
+
         // issue #26 P3: durable alias→handle registry that OUTLIVES the worker
         // process. `_entries` is torn down the instant a worker exits (crash, idle
         // timeout, reload), which used to drop the only record of an ad-hoc opened

--- a/src/GxMcp.Worker/Services/ObjectService.cs
+++ b/src/GxMcp.Worker/Services/ObjectService.cs
@@ -3655,11 +3655,19 @@ namespace GxMcp.Worker.Services
             {
                 if (normalizedPart == "source")
                 {
+                    if (obj is Procedure procedure && procedure.ProcedurePart != null)
+                        return procedure.ProcedurePart.Source ?? "";
                     dynamic sp = obj.Parts.Cast<KBObjectPart>().FirstOrDefault(p => p is ISource);
                     return sp?.Source ?? "";
                 }
                 if (normalizedPart == "rules")
                 {
+                    if (obj is Procedure procedure)
+                        return procedure.Rules?.Source ?? "";
+                    if (obj is Transaction transaction)
+                        return transaction.Rules?.Source ?? "";
+                    if (obj is WebPanel webPanel)
+                        return webPanel.Rules?.Source ?? "";
                     try { return ((dynamic)obj).Rules?.Source ?? ""; } catch { return ""; }
                 }
                 if (normalizedPart == "conditions")
@@ -3668,6 +3676,10 @@ namespace GxMcp.Worker.Services
                 }
                 if (normalizedPart == "events")
                 {
+                    if (obj is Transaction transaction)
+                        return transaction.Events?.Source ?? "";
+                    if (obj is WebPanel webPanel)
+                        return webPanel.Events?.Source ?? "";
                     try { return ((dynamic)obj).Events?.Source ?? ""; } catch { return ""; }
                 }
                 if (normalizedPart == "webform" || normalizedPart == "layout")

--- a/src/GxMcp.Worker/Services/SourceSearchService.cs
+++ b/src/GxMcp.Worker/Services/SourceSearchService.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Artech.Architecture.Common.Objects;
 using Artech.Genexus.Common.Parts;
 using GxMcp.Worker.Models;
+using GxMcp.Worker.Helpers;
 using Newtonsoft.Json.Linq;
 
 namespace GxMcp.Worker.Services
@@ -216,6 +217,7 @@ namespace GxMcp.Worker.Services
         {
             try
             {
+                var searchSw = System.Diagnostics.Stopwatch.StartNew();
                 if (string.IsNullOrEmpty(c.Callee) && string.IsNullOrEmpty(c.Pattern))
                     return Models.McpResponse.Err(code: "MissingCriteria", message: "Provide 'callee' (semantic) or 'pattern' (regex).");
 
@@ -249,7 +251,13 @@ namespace GxMcp.Worker.Services
                     // build this derived posting map during hydration. Asking for the
                     // map here keeps both paths correct without changing the fixture's
                     // other secondary-index semantics.
-                    try { _index.EnsureSourceTokenIndex(); } catch { }
+                    var tokenIndexSw = System.Diagnostics.Stopwatch.StartNew();
+                    try { _index.EnsureSourceTokenIndex(); }
+                    finally
+                    {
+                        tokenIndexSw.Stop();
+                        Logger.Info($"[SEARCH-SOURCE-PHASE] tokenIndexMs={tokenIndexSw.ElapsedMilliseconds} indexed={_index.GetIndex()?.SourceTokenIndex != null}");
+                    }
                 }
 
                 // Issue #27 item 4: an explicit objectName scope restricts the scan to
@@ -313,6 +321,7 @@ namespace GxMcp.Worker.Services
                 var entries = query
                     .Where(e => string.IsNullOrEmpty(c.TypeFilter) || string.Equals(e.Type, c.TypeFilter, StringComparison.OrdinalIgnoreCase))
                     .ToList();
+                Logger.Info($"[SEARCH-SOURCE-PHASE] candidateFilterMs={searchSw.ElapsedMilliseconds} candidates={entries.Count} literals={literals.Count} partial={partialIndex}");
 
                 // issue #36.7 — an objectName scope that resolved to zero entries must say so
                 // explicitly, not silently return "no hits" (indistinguishable from "found
@@ -337,6 +346,11 @@ namespace GxMcp.Worker.Services
 
                 int produced = 0;
                 int scanned = 0;
+                int sourceCacheHits = 0;
+                int sourceCacheMisses = 0;
+                int sdkResolutions = 0;
+                long sdkResolutionTicks = 0;
+                long sourceReadTicks = 0;
                 // Issue #27 item 4: index-addressable loop so a Timeout/Cancel can report a
                 // resumable nextCursor (the absolute entry index reached).
                 int resumeEntry = -1;
@@ -422,16 +436,21 @@ namespace GxMcp.Worker.Services
                             && _objectService.TryGetPartSourceRaw(e.Guid, part, out src))
                         {
                             haveSrc = true;
+                            sourceCacheHits++;
                         }
                         if (!haveSrc)
                         {
+                            sourceCacheMisses++;
                             if (obj == null)
                             {
                                 // Resolve the object ONCE per candidate; on failure bail the whole
                                 // candidate (review nit: a per-part `continue` here would re-attempt
                                 // FindObject for every remaining part of the same candidate).
+                                var resolveStart = System.Diagnostics.Stopwatch.GetTimestamp();
                                 try { obj = _objectService.FindObject(e); }
                                 catch { obj = null; }
+                                sdkResolutions++;
+                                sdkResolutionTicks += System.Diagnostics.Stopwatch.GetTimestamp() - resolveStart;
                                 if (obj == null)
                                 {
                                     var diagnostic = _objectService?.GetLastResolutionDiagnostic();
@@ -440,9 +459,11 @@ namespace GxMcp.Worker.Services
                                     break;
                                 }
                             }
+                            var sourceReadStart = System.Diagnostics.Stopwatch.GetTimestamp();
                             src = _objectService != null
                                 ? _objectService.ReadPartSourceRaw(obj, part)
                                 : TryGetPartSource(obj, part);
+                            sourceReadTicks += System.Diagnostics.Stopwatch.GetTimestamp() - sourceReadStart;
                         }
                         if (string.IsNullOrEmpty(src)) continue;
 
@@ -696,6 +717,7 @@ namespace GxMcp.Worker.Services
                     resultPayload["unresolvedObjects"] = unresolvedObjects;
                     resultPayload["unresolvedHint"] = "The index listed these objects, but the active SDK could not resolve their native identity; no source was inferred for them.";
                 }
+                Logger.Info($"[SEARCH-SOURCE-PHASE] sdkResolveMs={(long)(sdkResolutionTicks * 1000.0 / System.Diagnostics.Stopwatch.Frequency)} sourceReadMs={(long)(sourceReadTicks * 1000.0 / System.Diagnostics.Stopwatch.Frequency)} resolutions={sdkResolutions} cacheHits={sourceCacheHits} cacheMisses={sourceCacheMisses} scanned={scanned} totalMs={searchSw.ElapsedMilliseconds}");
                 if (hits.Count > 0 && hits[0] is JObject topHit)
                 {
                     resultPayload["_meta"] = new JObject
@@ -1015,11 +1037,22 @@ namespace GxMcp.Worker.Services
             {
                 if (string.Equals(partName, "source", StringComparison.OrdinalIgnoreCase))
                 {
+                    // Procedure exposes its native source part directly. Avoiding Parts
+                    // enumeration and dynamic dispatch is the cheapest SDK-only path;
+                    // other object kinds retain the compatibility fallback below.
+                    if (obj is Artech.Genexus.Common.Objects.Procedure procedure && procedure.ProcedurePart != null)
+                        return procedure.ProcedurePart.Source ?? "";
                     dynamic sp = obj.Parts.Cast<KBObjectPart>().FirstOrDefault(p => p is ISource);
                     return sp?.Source ?? "";
                 }
                 if (string.Equals(partName, "rules", StringComparison.OrdinalIgnoreCase))
                 {
+                    if (obj is Artech.Genexus.Common.Objects.Procedure procedure)
+                        return procedure.Rules?.Source ?? "";
+                    if (obj is Artech.Genexus.Common.Objects.Transaction transaction)
+                        return transaction.Rules?.Source ?? "";
+                    if (obj is Artech.Genexus.Common.Objects.WebPanel webPanel)
+                        return webPanel.Rules?.Source ?? "";
                     try { return ((dynamic)obj).Rules?.Source ?? ""; } catch { return ""; }
                 }
                 if (string.Equals(partName, "conditions", StringComparison.OrdinalIgnoreCase))
@@ -1028,6 +1061,10 @@ namespace GxMcp.Worker.Services
                 }
                 if (string.Equals(partName, "events", StringComparison.OrdinalIgnoreCase))
                 {
+                    if (obj is Artech.Genexus.Common.Objects.Transaction transaction)
+                        return transaction.Events?.Source ?? "";
+                    if (obj is Artech.Genexus.Common.Objects.WebPanel webPanel)
+                        return webPanel.Events?.Source ?? "";
                     try { return ((dynamic)obj).Events?.Source ?? ""; } catch { return ""; }
                 }
                 // WebForm / Layout — the visual XML of WebPanels/Transactions. Not an


### PR DESCRIPTION
## Escopo completo

Este PR inclui todos os itens acumulados nesta branch, além da otimização de acesso ao SDK/STA:

### Performance e SDK GeneXus

- Fast path nativo para `ProcedurePart.Source` no caminho real de leitura do Worker.
- Accessors tipados para `Rules` e `Events` em Procedures, Transactions e WebPanels.
- Fallback dinâmico preservado para variantes do SDK e objetos sem accessor tipado.
- Comparação live entre propriedade direta e `Parts.Get<ProcedurePart>()`; a propriedade direta foi mantida por apresentar cauda mais estável.
- Instrumentação de `search_source` por fase: filtro, índice, resolução SDK, leitura de source, cache e duração total.

### Worker, STA e ciclo de vida

- Aquisições de Worker coalescidas por caminho físico da KB, evitando Workers duplicados quando aliases apontam para a mesma pasta.
- Warmup e bootstrap do índice serializados para evitar corridas no SDK STA e loops de `BusyReject`.
- Resolução de objetos por EntityKey/GUID com caminho O(1) antes dos fallbacks por nome/caminho.
- Cache-first por source/part e redução de chamadas SDK repetidas.

### Gateway e contratos

- Correções no envelope de idempotência e validação do contrato de chaves.
- Novo `PropertyFuzzContractTests` para validação, canonicalização e deduplicação concorrente.
- Preservação dos contratos de resposta e metadados MCP.

### Benchmarks live e harness

- Melhorias no benchmark HTTP com métricas de payload, tokens, conteúdo estruturado e comparação de regressões.
- Harness live com progresso incremental, fases explícitas, limpeza de logs e diagnósticos de timeout.
- Fixture GeneXus 18 validada na `C:\KBs\KBTeste`, incluindo a procedure `McpSdkAccessorBench` com source de 500 linhas.

## Evidência de performance

Benchmark oficial de `search_source` na mesma fixture:

| Métrica | Antes | Depois |
|---|---:|---:|
| p95 | 2.348,2 ms | 1.431,2 ms |
| p99 | 3.350,3 ms | 2.038,2 ms |
| média | 456,1 ms | 281,9 ms |

Bateria quente estável após o fast path:

```text
p50: 1,4 ms
p95: 14,9 ms
p99: 15,6 ms
média: 4,6 ms
```

A alternativa `Parts.Get<ProcedurePart>()` apresentou p50 de 0,9 ms, mas p95 de 16,6 ms e p99 de 23,3 ms; por isso a propriedade direta foi escolhida como variante mais estável.

## Validação

- `dotnet test Genexus18MCP.sln`: 3.836 passed, 17 skipped, 0 failed.
- Testes focados do Worker: 125 passed, 0 failed, 0 skipped.
- `npm test`: 90 passed, 0 failed.
- `npm run lint`: passed.
- `git diff --check`: passed.
- CI do GitHub Actions: SUCCESS.

## Commit

`77675e1befdcfd2184aea74de1d233b82093ebd1`
