### PR TITLE
Preserva metadados em prévias e edições pontuais de PatternInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Preserve SDK-owned pattern metadata during raw XML property edits and previews. Unchanged XML is a no-op; structural or metadata changes are rejected explicitly instead of rebuilding child-order lists. Preview and save share the same unmodified payload, and unreadable current XML blocks both paths. This does not certify SDK save isolation.
+
 - Respect requested object types when resolving homonyms, including Pattern Settings, and separate read-cache entries by type and read shape.
 - Read Pattern Settings through the SDK pattern tree with explicit pagination instead of the generic properties XML.
 

--- a/docs/pattern-xml-property-edits.md
+++ b/docs/pattern-xml-property-edits.md
@@ -1,0 +1,31 @@
+# Raw pattern XML property edits
+
+Raw `PatternInstance` XML edits now preserve the current SDK metadata rather
+than rebuilding `childrenOrderedList`. XML document order is not a reliable
+description of WorkWithPlus's internal rendering metadata: valid serialized
+lists may include entries without direct XML children.
+
+An unchanged document returns `WriteNoChange`. A property-only edit with the
+same tree and identities returns `WriteDryRun` with exact attribute paths,
+`before`/`after` values and `savePathExercised: false`. The preview and write
+preflight share one pure plan and the same original request string; no SDK
+deserializer or save is invoked by the preview. Failure to read the current
+document rejects both paths with `PatternReadFailed`.
+
+Structural edits previously accepted by the raw route now fail explicitly with
+`PatternStructureChangeUnsupported`; changes to defaults, templates, child-order
+metadata or node identities fail with `PatternMetadataChangeUnsupported`.
+This includes adding/removing those attributes, renaming named nodes and moving
+identified siblings. Namespaced attributes are compared by their full XML name.
+Meaningful text, comments and CDATA must remain unchanged. Inter-element
+formatting whitespace can differ; DTDs are unsupported.
+
+Use the appropriate SDK pattern authoring action for structural operations,
+reviewing its documented side effects. Anonymous siblings with identical element
+names have positional identity: exchanging only their editable attribute values
+is indistinguishable from property edits. The raw route does not infer a layout
+reordering from those values and never repairs their internal lists.
+
+This preflight is not an SDK save-isolation guarantee. Existing save behavior,
+pattern projection and Events/Settings isolation protections are unchanged.
+Do not use a successful property preview as authorization for an isolated save.

--- a/src/GxMcp.Worker.Tests/EdgeCaseRegressionTests.cs
+++ b/src/GxMcp.Worker.Tests/EdgeCaseRegressionTests.cs
@@ -238,7 +238,8 @@ namespace GxMcp.Worker.Tests
             // because the producing method is private and the path needs a
             // live KB to exercise end-to-end.
             string writeSrc = System.IO.File.ReadAllText(FindWorkerServiceFile("WriteService.PatternWrite.cs"));
-            Assert.Contains("code: \"PatternInvalidXml\"", writeSrc);
+            Assert.Equal("PatternInvalidXml", GxMcp.Worker.Helpers.PatternXmlEditPlan.Create("<instance/>", "<invalid").ErrorCode);
+            Assert.Contains("code: plan.ErrorCode", writeSrc);
             Assert.Contains("code: \"PatternPartNotFound\"", writeSrc);
             Assert.Contains("code: \"PatternVerificationMismatch\"", writeSrc);
             Assert.Contains("code: \"PatternSaveFailed\"", writeSrc);

--- a/src/GxMcp.Worker.Tests/PatternDryRunPrecheckTests.cs
+++ b/src/GxMcp.Worker.Tests/PatternDryRunPrecheckTests.cs
@@ -33,7 +33,7 @@ namespace GxMcp.Worker.Tests
             Assert.Contains("code: \"VisualReadFailed\"", visualSrc);
 
             // 3. PatternWrite dryRun includes verified array, savePathExercised = false, and PatternInstance warning
-            Assert.Contains("[\"verified\"] = new JArray(\"xmlParse\", \"childrenOrderedList\", \"diffVsCurrent\")", patternSrc);
+            Assert.Contains("[\"verified\"] = new JArray(\"xmlParse\", \"metadataPreserved\", \"structurePreserved\", \"diffVsCurrent\")", patternSrc);
             Assert.Contains("[\"savePathExercised\"] = false", patternSrc);
             Assert.Contains("WorkWithPlus pattern saves can still be rejected by the WWP validator on save", patternSrc);
 

--- a/src/GxMcp.Worker.Tests/PatternReconcileAttachmentTests.cs
+++ b/src/GxMcp.Worker.Tests/PatternReconcileAttachmentTests.cs
@@ -2,14 +2,11 @@ using Xunit;
 
 namespace GxMcp.Worker.Tests
 {
-    // Friction 2026-05-28 — DryRun + verify-failed pattern envelopes now
-    // attach the PatternChildOrderReconciler report so validate=only callers
-    // see which parents the reconciler had to fix or skip. Source-level
-    // convention test: exercising the live path needs a WWP host.
+    // Raw XML edits must never infer SDK-owned metadata.
     public class PatternReconcileAttachmentTests
     {
         [Fact]
-        public void WriteService_AttachReconcileReport_IsWired_ViaConvention()
+        public void WriteService_UsesSamePurePlanBeforePreviewAndSave()
         {
             // Definition + call sites now live in split partial files (plan 007).
             System.IO.DirectoryInfo dir = new System.IO.DirectoryInfo(System.AppDomain.CurrentDomain.BaseDirectory);
@@ -23,15 +20,12 @@ namespace GxMcp.Worker.Tests
             string writeSrc = System.IO.File.ReadAllText(System.IO.Path.Combine(servicesDir, "WriteService.VisualWrite.cs"))
                 + System.IO.File.ReadAllText(System.IO.Path.Combine(servicesDir, "WriteService.PatternWrite.cs"));
 
-            // Helper is defined.
-            Assert.Contains("private static void AttachReconcileReport", writeSrc);
-            // Both dry-run paths attach the report.
-            Assert.Contains("AttachReconcileReport(dryResp, reconcileReport);", writeSrc);
-            // Verify-failed envelope attaches it too.
-            Assert.Contains("AttachReconcileReport(verifyJobj, reconcileReport);", writeSrc);
-            // Output shape includes parentsUpdated + skipsHint.
-            Assert.Contains("[\"parentsUpdated\"] = report.ParentsUpdated", writeSrc);
-            Assert.Contains("skipsHint", writeSrc);
+            Assert.Contains("PatternXmlEditPlan.Create(currentXml, xml)", writeSrc);
+            Assert.Contains("string normalizedInput = plan.Xml;", writeSrc);
+            Assert.DoesNotContain("PatternChildOrderReconciler.Reconcile", writeSrc);
+            Assert.DoesNotContain("AttachReconcileReport", writeSrc);
+            Assert.True(writeSrc.IndexOf("if (plan.IsNoChange)") < writeSrc.IndexOf("string normalizedInput = plan.Xml;"));
+            Assert.True(writeSrc.IndexOf("if (plan.ErrorCode != null)") < writeSrc.IndexOf("ApplyPatternEnvelope(resolvedPart, envelope, normalizedInput)"));
         }
     }
 }

--- a/src/GxMcp.Worker.Tests/PatternXmlEditPlanTests.cs
+++ b/src/GxMcp.Worker.Tests/PatternXmlEditPlanTests.cs
@@ -1,0 +1,149 @@
+using System.Xml.Linq;
+using GxMcp.Worker.Helpers;
+using Xunit;
+
+namespace GxMcp.Worker.Tests
+{
+    public class PatternXmlEditPlanTests
+    {
+        // Deliberately uses an order list that differs from document order.
+        private const string Original = "<instance templateId='sample' DefaultMode='true'><table name='Main' childrenOrderedList='2;27;B|2;27;A' class='Table'><textBlock name='A' caption='Alpha'/><textBlock name='B' caption='Beta'/></table></instance>";
+
+        [Fact]
+        public void OriginalXmlIsNoOpEvenWhenReconcilerWouldChangeIt()
+        {
+            var doc = XDocument.Parse(Original);
+            Assert.True(PatternChildOrderReconciler.Reconcile(doc).ParentsUpdated > 0);
+            var plan = PatternXmlEditPlan.Create(Original, Original);
+            Assert.True(plan.IsNoChange);
+            Assert.Equal(Original, plan.Xml);
+            Assert.Empty(plan.Changes);
+        }
+
+        [Fact]
+        public void DoesNotInventListsOrRemoveEntriesWithoutDirectChildren()
+        {
+            const string xml = "<instance><table childrenOrderedList='2;27;SyntheticGhost'><table><textBlock name='Message' caption='Old'/></table></table></instance>";
+            var requested = xml.Replace("Old", "New");
+            var plan = PatternXmlEditPlan.Create(xml, requested);
+            Assert.Null(plan.ErrorCode);
+            Assert.Equal(requested, plan.Xml);
+            Assert.Single(XDocument.Parse(plan.Xml).Descendants().Attributes("childrenOrderedList"));
+            Assert.Single(plan.Changes);
+        }
+
+        [Theory]
+        [InlineData("class='Table'", "class='Table entry'")]
+        [InlineData("caption='Alpha'", "caption='Hello'")]
+        public void PropertyChangeHasExactDiffAndDoesNotNormalizePayload(string from, string to)
+        {
+            var requested = Original.Replace(from, to);
+            var plan = PatternXmlEditPlan.Create(Original, requested);
+            Assert.Null(plan.ErrorCode);
+            Assert.False(plan.IsNoChange);
+            Assert.Equal(requested, plan.Xml);
+            Assert.Single(plan.Changes);
+            Assert.Equal(from.Split('\'')[1], (string)plan.Changes[0]["before"]);
+            Assert.Equal(to.Split('\'')[1], (string)plan.Changes[0]["after"]);
+            Assert.Contains("childrenOrderedList='2;27;B|2;27;A'", plan.Xml);
+        }
+
+        [Theory]
+        [InlineData("DefaultMode='true'", "DefaultMode='false'")]
+        [InlineData("templateId='sample'", "templateId='other'")]
+        [InlineData("name='A'", "name='Renamed'")]
+        [InlineData("childrenOrderedList='2;27;B|2;27;A'", "childrenOrderedList='2;27;A|2;27;B'")]
+        [InlineData("DefaultMode='true'", "")]
+        [InlineData("<table name", "<table id='new' name")]
+        public void MetadataChangesAreRejectedWithoutProducingAPartialPlan(string from, string to)
+        {
+            var plan = PatternXmlEditPlan.Create(Original, Original.Replace("class='Table'", "class='Changed'").Replace(from, to));
+            Assert.Equal("PatternMetadataChangeUnsupported", plan.ErrorCode);
+            Assert.Empty(plan.Changes);
+        }
+
+        [Theory]
+        [InlineData("<textBlock name='A' caption='Alpha'/>", "")]
+        [InlineData("</table>", "<table name='New'/></table>")]
+        [InlineData("<textBlock name='A' caption='Alpha'/><textBlock name='B' caption='Beta'/>", "<textBlock name='B' caption='Beta'/><textBlock name='A' caption='Alpha'/>")]
+        public void StructuralEditsAreRejected(string from, string to)
+        {
+            var plan = PatternXmlEditPlan.Create(Original, Original.Replace(from, to));
+            Assert.NotNull(plan.ErrorCode);
+            Assert.Empty(plan.Changes);
+        }
+
+        [Fact]
+        public void NamespacesAndTextRemainUntouchedForPropertyEdits()
+        {
+            const string xml = "<p:instance xmlns:p='urn:pattern'><p:table name='Main' p:class='Old'>keep &amp; preserve<![CDATA[ literal ]]><!-- note --></p:table></p:instance>";
+            var requested = xml.Replace("p:class='Old'", "p:class='New'");
+            var plan = PatternXmlEditPlan.Create(xml, requested);
+            Assert.Null(plan.ErrorCode);
+            Assert.Equal(requested, plan.Xml);
+            Assert.Contains("{urn:pattern}class", (string)plan.Changes[0]["path"]);
+            Assert.NotNull(PatternXmlEditPlan.Create(xml, xml.Replace("urn:pattern", "urn:other")).ErrorCode);
+            Assert.NotNull(PatternXmlEditPlan.Create(xml, xml.Replace("preserve", "change")).ErrorCode);
+        }
+
+        [Fact]
+        public void MetadataRepresentedAsElementsIsProtected()
+        {
+            const string xml = "<instance><DefaultValues><property value='old'/></DefaultValues></instance>";
+            Assert.Equal("PatternMetadataChangeUnsupported", PatternXmlEditPlan.Create(xml, xml.Replace("old", "new")).ErrorCode);
+        }
+
+        [Fact]
+        public void AttributeNodeCaptionCanChangeWithoutChangingItsIdentity()
+        {
+            const string xml = "<instance><attribute attribute='field-ref' caption='Old'/></instance>";
+            Assert.Null(PatternXmlEditPlan.Create(xml, xml.Replace("Old", "New")).ErrorCode);
+            Assert.Equal("PatternMetadataChangeUnsupported", PatternXmlEditPlan.Create(xml, xml.Replace("field-ref", "other-ref")).ErrorCode);
+        }
+
+        [Fact]
+        public void FormattingOnlyIsNoOpButSignificantWhitespaceIsNot()
+        {
+            Assert.True(PatternXmlEditPlan.Create(Original, Original.Replace("><", ">\n  <")).IsNoChange);
+            const string text = "<instance><value> </value></instance>";
+            Assert.NotNull(PatternXmlEditPlan.Create(text, text.Replace("> <", ">  <")).ErrorCode);
+        }
+
+        [Theory]
+        [InlineData("label")]
+        [InlineData("<![CDATA[ ]]>")]
+        public void MixedContentWhitespaceCannotChangeAlongsideProperty(string text)
+        {
+            var xml = "<instance>" + text + "<table class='Old'/> </instance>";
+            var propertyOnly = xml.Replace("Old", "New");
+            Assert.Null(PatternXmlEditPlan.Create(xml, propertyOnly).ErrorCode);
+            var plan = PatternXmlEditPlan.Create(xml, propertyOnly.Replace("/> </", "/>  </"));
+            Assert.Equal("PatternStructureChangeUnsupported", plan.ErrorCode);
+            Assert.Empty(plan.Changes);
+        }
+
+        [Theory]
+        [InlineData("<?change command?>")]
+        [InlineData("<!-- altered -->")]
+        [InlineData("<!DOCTYPE instance [<!ENTITY example 'value'>]>")]
+        public void AddedDocumentMetadataIsRejected(string prefix)
+        {
+            Assert.Equal("PatternStructureChangeUnsupported", PatternXmlEditPlan.Create(Original, prefix + Original).ErrorCode);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("<broken")]
+        public void UnreadableCurrentXmlFailsClosed(string current)
+        {
+            Assert.Equal("PatternReadFailed", PatternXmlEditPlan.Create(current, Original).ErrorCode);
+        }
+
+        [Fact]
+        public void InvalidInputIsRejected()
+        {
+            Assert.Equal("PatternInvalidXml", PatternXmlEditPlan.Create(Original, "<broken").ErrorCode);
+        }
+    }
+}

--- a/src/GxMcp.Worker/Helpers/PatternXmlEditPlan.cs
+++ b/src/GxMcp.Worker/Helpers/PatternXmlEditPlan.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace GxMcp.Worker.Helpers
+{
+    // Pure preflight for raw XML edits. SDK-owned order/defaults are not derivable
+    // from document order. Keep the caller's payload intact; never repair metadata.
+    public sealed class PatternXmlEditPlan
+    {
+        public string Xml { get; private set; }
+        public string ErrorCode { get; private set; }
+        public string Error { get; private set; }
+        public JArray Changes { get; } = new JArray();
+        public bool IsNoChange => ErrorCode == null && Changes.Count == 0;
+
+        public static PatternXmlEditPlan Create(string currentXml, string requestedXml)
+        {
+            var plan = new PatternXmlEditPlan { Xml = requestedXml };
+            XDocument current, requested;
+            try { requested = XDocument.Parse(requestedXml, LoadOptions.PreserveWhitespace); }
+            catch (Exception ex) { return plan.Reject("PatternInvalidXml", ex.Message); }
+            try { current = XDocument.Parse(currentXml, LoadOptions.PreserveWhitespace); }
+            catch (Exception ex) { return plan.Reject("PatternReadFailed", "Cannot compare current pattern: " + ex.Message); }
+            var oldOutside = current.Nodes().Where(n => !(n is XElement)).ToArray();
+            var newOutside = requested.Nodes().Where(n => !(n is XElement)).ToArray();
+            if (current.DocumentType != null || requested.DocumentType != null
+                || current.Declaration?.ToString() != requested.Declaration?.ToString()
+                || oldOutside.Length != newOutside.Length
+                || oldOutside.Where((n, i) => !XNode.DeepEquals(n, newOutside[i])).Any())
+                return plan.Reject("PatternStructureChangeUnsupported", "Document declarations or nodes outside the pattern root changed (DTDs are unsupported).");
+            plan.Compare(current.Root, requested.Root, "/");
+            return plan;
+        }
+
+        private PatternXmlEditPlan Reject(string code, string detail)
+        {
+            ErrorCode = code;
+            Error = detail;
+            Changes.Clear();
+            return this;
+        }
+
+        private void Compare(XElement before, XElement after, string path)
+        {
+            if (ErrorCode != null) return;
+            path += before.Name + "/";
+            if (before.Name != after.Name)
+            {
+                Reject("PatternStructureChangeUnsupported", "Element identity changed at " + path);
+                return;
+            }
+            foreach (var name in before.Attributes().Select(a => a.Name).Union(after.Attributes().Select(a => a.Name)))
+            {
+                var left = before.Attribute(name);
+                var right = after.Attribute(name);
+                if ((string)left == (string)right) continue;
+                if (IsProtected(name.LocalName) || left?.IsNamespaceDeclaration == true || right?.IsNamespaceDeclaration == true)
+                {
+                    Reject("PatternMetadataChangeUnsupported", "SDK-owned metadata or identity changed at " + path + "@" + name);
+                    return;
+                }
+                Changes.Add(new JObject { ["path"] = path + "@" + name, ["before"] = (string)left, ["after"] = (string)right });
+            }
+            var oldNodes = before.Nodes().Where(Significant).ToArray();
+            var newNodes = after.Nodes().Where(Significant).ToArray();
+            if (oldNodes.Length != newNodes.Length)
+            {
+                Reject("PatternStructureChangeUnsupported", "Child structure changed at " + path);
+                return;
+            }
+            for (int i = 0; i < oldNodes.Length; i++)
+            {
+                if (oldNodes[i] is XElement oldElement && newNodes[i] is XElement newElement)
+                {
+                    if (IsMetadata(oldElement.Name.LocalName) && !XNode.DeepEquals(oldElement, newElement))
+                        Reject("PatternMetadataChangeUnsupported", "SDK-owned metadata changed at " + path + oldElement.Name);
+                    else
+                        Compare(oldElement, newElement, path + "[" + i + "]/");
+                }
+                else if (!XNode.DeepEquals(oldNodes[i], newNodes[i]))
+                    Reject("PatternStructureChangeUnsupported", "Text or node structure changed at " + path);
+                if (ErrorCode != null) return;
+            }
+        }
+
+        private static bool Significant(XNode node) => !(node is XText text)
+            || node is XCData || !string.IsNullOrWhiteSpace(text.Value)
+            || !node.Parent.Elements().Any()
+            || node.Parent.Nodes().OfType<XText>().Any(t => t is XCData || !string.IsNullOrWhiteSpace(t.Value))
+            || node.Parent.AncestorsAndSelf().Any(e => (string)e.Attribute(XNamespace.Xml + "space") == "preserve");
+
+        private static bool IsMetadata(string name) => name.StartsWith("default", StringComparison.OrdinalIgnoreCase)
+            || name.StartsWith("template", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("childrenOrderedList", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsProtected(string name)
+        {
+            return IsMetadata(name)
+                || name.Equals("name", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("controlName", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("blockName", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("attribute", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("id", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("type", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("identifier", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("patternId", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("guid", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("key", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("entityKey", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/GxMcp.Worker/Services/WriteService.PatternWrite.cs
+++ b/src/GxMcp.Worker/Services/WriteService.PatternWrite.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
 using GxMcp.Worker.Helpers;
 
@@ -14,82 +13,41 @@ namespace GxMcp.Worker.Services
     {
         private string WritePatternPart(global::Artech.Architecture.Common.Objects.KBObject obj, string target, string partName, string xml, bool dryRun = false, bool strictVerify = true)
         {
-            string normalizedInput;
-            GxMcp.Worker.Helpers.PatternChildOrderReconciler.Report reconcileReport;
+            string currentXml;
             try
             {
-                var doc = XDocument.Parse(xml, LoadOptions.PreserveWhitespace);
-                // Auto-reconcile childrenOrderedList so callers (LLMs) can add/remove/reorder
-                // children purely by editing XML — the helper rebuilds each parent's
-                // ordering attribute from the live child tree. Without this, an LLM that
-                // adds a <textBlock> but forgets to update childrenOrderedList ships a
-                // technically-valid XML that the IDE renders incorrectly. See
-                // src/GxMcp.Worker/Helpers/PatternChildOrderReconciler.cs for the rules.
-                reconcileReport = GxMcp.Worker.Helpers.PatternChildOrderReconciler.Reconcile(doc);
-                if (reconcileReport.ParentsUpdated > 0)
-                {
-                    Logger.Info("[PATTERN-WRITE] Auto-reconciled childrenOrderedList on " + reconcileReport.ParentsUpdated + " parent(s).");
-                    foreach (var change in reconcileReport.Changes)
-                    {
-                        Logger.Info("[PATTERN-WRITE]   " + change);
-                    }
-                }
-                foreach (var skip in reconcileReport.Skips)
-                {
-                    Logger.Warn("[PATTERN-WRITE]   skipped: " + skip);
-                }
-                normalizedInput = doc.ToString();
+                currentXml = _patternAnalysisService.ReadPatternPartXml(obj, partName, out _, out _);
             }
             catch (Exception ex)
             {
-                return CreateWriteError("Invalid pattern XML", target, partName, ex.Message, obj, code: "PatternInvalidXml");
+                return CreateWriteError("Pattern precheck failed", target, partName, ex.Message, obj, code: "PatternReadFailed");
             }
 
-            try
-            {
-                string currentXml = _patternAnalysisService.ReadPatternPartXml(obj, partName, out _, out _);
-                if (XmlEquivalence.AreEquivalent(currentXml, normalizedInput, out _))
+            var plan = PatternXmlEditPlan.Create(currentXml, xml);
+            if (plan.ErrorCode != null)
+                return CreateWriteError("Pattern edit rejected", target, partName,
+                    plan.Error + " Use the appropriate SDK pattern authoring action for structural edits; this does not certify save isolation.",
+                    obj, code: plan.ErrorCode);
+            if (plan.IsNoChange)
+                return Models.McpResponse.Ok(target: target, code: "WriteNoChange", result: new JObject
                 {
-                    return Models.McpResponse.Ok(
-                        target: target,
-                        code: "WriteNoChange",
-                        result: new JObject
-                        {
-                            ["part"] = partName,
-                            ["details"] = dryRun ? "Dry-run: no change would be applied." : "No change"
-                        });
-                }
-                if (dryRun)
+                    ["part"] = partName,
+                    ["details"] = dryRun ? "Dry-run: no change would be applied." : "No change",
+                    ["savePathExercised"] = false
+                });
+            if (dryRun)
+                return Models.McpResponse.Ok(target: target, code: "WriteDryRun", result: new JObject
                 {
-                    var dryResp = new JObject
-                    {
-                        ["part"] = partName,
-                        ["details"] = "Dry-run: input parsed and would update pattern XML. Save skipped.",
-                        ["verified"] = new JArray("xmlParse", "childrenOrderedList", "diffVsCurrent"),
-                        ["savePathExercised"] = false
-                    };
-                    if (string.Equals(partName, "PatternInstance", StringComparison.OrdinalIgnoreCase))
-                    {
-                        dryResp["warning"] = "Dry-run verified XML structure and diff against current pattern. Note: WorkWithPlus pattern saves can still be rejected by the WWP validator on save.";
-                    }
-                    AttachReconcileReport(dryResp, reconcileReport);
-                    return Models.McpResponse.Ok(target: target, code: "WriteDryRun", result: dryResp);
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Debug("[DEBUG-SAVE] Pattern no-change precheck skipped: " + ex.Message);
-                if (dryRun)
-                {
-                    return CreateWriteError(
-                        "Pattern dry-run precheck failed",
-                        target,
-                        partName,
-                        "Dry-run input parsed, but reading current pattern failed (" + ex.Message + "). State comparison skipped.",
-                        obj,
-                        code: "PatternReadFailed");
-                }
-            }
+                    ["part"] = partName,
+                    ["details"] = "Dry-run: property changes validated; metadata preserved. Save skipped.",
+                    ["verified"] = new JArray("xmlParse", "metadataPreserved", "structurePreserved", "diffVsCurrent"),
+                    ["changes"] = plan.Changes,
+                    ["savePathExercised"] = false,
+                    ["warning"] = "WorkWithPlus pattern saves can still be rejected by the WWP validator on save. This preview does not certify save isolation."
+                });
+
+            // Preview and persistence use exactly the same validated payload.
+            string normalizedInput = plan.Xml;
 
             LogRequestedPatternPayloadIfEnabled(normalizedInput);
 
@@ -270,25 +228,6 @@ namespace GxMcp.Worker.Services
                                     errObj["verifyDiff"] = verifyJobj["verifyDiff"];
                                     verifyJobj.Remove("verifyDiff");
                                 }
-                                // Move childOrderReconcile into error when verification failed.
-                                if (verifyJobj["childOrderReconcile"] != null && errObj["childOrderReconcile"] == null)
-                                {
-                                    errObj["childOrderReconcile"] = verifyJobj["childOrderReconcile"];
-                                    verifyJobj.Remove("childOrderReconcile");
-                                }
-                                // Attach reconcile report under error.childOrderReconcile.
-                                if (reconcileReport != null && reconcileReport.HasContent && errObj["childOrderReconcile"] == null)
-                                {
-                                    var rcObj = new JObject { ["parentsUpdated"] = reconcileReport.ParentsUpdated };
-                                    if (reconcileReport.Changes != null && reconcileReport.Changes.Count > 0)
-                                        rcObj["changes"] = new JArray(reconcileReport.Changes);
-                                    if (reconcileReport.Skips != null && reconcileReport.Skips.Count > 0)
-                                    {
-                                        rcObj["skips"] = new JArray(reconcileReport.Skips);
-                                        rcObj["skipsHint"] = "Reconciler refused to rebuild childrenOrderedList for these parents.";
-                                    }
-                                    errObj["childOrderReconcile"] = rcObj;
-                                }
                             }
                             else
                             {
@@ -296,7 +235,6 @@ namespace GxMcp.Worker.Services
                                 if (persistedSnippet != null) verifyJobj["persistedSnippet"] = persistedSnippet;
                                 if (requestedSnippet != null) verifyJobj["requestedSnippet"] = requestedSnippet;
                                 if (sdkSaveError != null) verifyJobj["sdkSaveError"] = sdkSaveError;
-                                AttachReconcileReport(verifyJobj, reconcileReport);
                             }
                             // Inject restore nextStep so the caller knows how to roll back.
                             {
@@ -437,38 +375,6 @@ namespace GxMcp.Worker.Services
                         {
                             Logger.Debug("[WWP-PROJECT] auto-project on edit skipped: " + ex.Message);
                         }
-                    }
-
-                    // Echo the auto-reconcile report so LLM callers can see exactly
-                    // which childrenOrderedList values the MCP rewrote and why. The IDE
-                    // hides children that aren't listed; if a caller forgot to update
-                    // the attribute by hand, this block tells them the MCP did it for
-                    // them (or, with `skips`, that it could NOT and the layout may not
-                    // render — that's an actionable signal).
-                    if (reconcileReport.HasContent)
-                    {
-                        var ordering = new JObject
-                        {
-                            ["parentsUpdated"] = reconcileReport.ParentsUpdated,
-                            ["explanation"] = "WorkWithPlus uses `childrenOrderedList` on each container element to drive IDE rendering order. The MCP rebuilds it from the XML's actual child order so callers only need to place elements where they want them in the tree."
-                        };
-                        if (reconcileReport.Changes.Count > 0)
-                        {
-                            ordering["changes"] = new JArray(reconcileReport.Changes);
-                        }
-                        if (reconcileReport.Skips.Count > 0)
-                        {
-                            ordering["skipped"] = new JArray(reconcileReport.Skips);
-                            ordering["willRender"] = false;
-                            ordering["skipNote"] = "These parents were left untouched because their childrenOrderedList could not be inferred safely; the affected children may not render in the IDE until the list is corrected manually.";
-                            // issue #36.3 — escalate the skip from a footnote to a top-level
-                            // warning: the write persisted but the affected controls will NOT
-                            // render in the IDE, which is an actionable failure the caller
-                            // must see, not a note buried in the reconciliation block.
-                            success["warning"] = "Layout persisted, but " + reconcileReport.Skips.Count +
-                                " container(s) could not be reconciled and their controls will NOT render in the IDE. Give the container a name/title, or fix its childrenOrderedList in the IDE. See childrenOrderedListReconciliation.skipped.";
-                        }
-                        success["childrenOrderedListReconciliation"] = ordering;
                     }
 
                     return Models.McpResponse.Ok(target: target, code: "WriteApplied", result: success);

--- a/src/GxMcp.Worker/Services/WriteService.VisualWrite.cs
+++ b/src/GxMcp.Worker/Services/WriteService.VisualWrite.cs
@@ -668,32 +668,6 @@ namespace GxMcp.Worker.Services
 
         // Walks ex.InnerException so the deepest message — usually the real SDK
         // diagnostic — ends up in the response. Outer wrappers are still surfaced
-        // Friction 2026-05-28 — surface the PatternChildOrderReconciler
-        // report on both DryRun and verify-failed envelopes so the caller
-        // sees which parents the reconciler had to fix (or skip) without
-        // needing live worker logs. validate=only callers rely on this to
-        // catch malformed childrenOrderedList before paying for a write.
-        private static void AttachReconcileReport(
-            JObject envelope,
-            GxMcp.Worker.Helpers.PatternChildOrderReconciler.Report report)
-        {
-            if (envelope == null || report == null || !report.HasContent) return;
-            var jo = new JObject
-            {
-                ["parentsUpdated"] = report.ParentsUpdated
-            };
-            if (report.Changes != null && report.Changes.Count > 0)
-            {
-                jo["changes"] = new JArray(report.Changes);
-            }
-            if (report.Skips != null && report.Skips.Count > 0)
-            {
-                jo["skips"] = new JArray(report.Skips);
-                jo["skipsHint"] = "Reconciler refused to rebuild childrenOrderedList for these parents — the XML is missing identifiers (controlName/Name/attribute) or has an unknown child kind. Fix those entries before retrying.";
-            }
-            envelope["childOrderReconcile"] = jo;
-        }
-
         // but only when they add information beyond the inner message.
         internal static string TryExtractFormType(string xml)
         {


### PR DESCRIPTION
O editor XML de PatternInstance executava o reconciliador global antes de comparar o conteúdo atual e antes de sair do dryRun. Até um XML exportado sem edição podia gerar listas internas novas, remover entradas existentes e produzir avisos indevidos.

A correção usa um plano puro: no-op retorna WriteNoChange; alterações de propriedades preservam o payload original e expõem caminhos e valores antes/depois. Defaults, templates, listas de ordem, identidades, texto significativo e estrutura são protegidos. Falha de leitura bloqueia a operação. Preview e preflight de gravação usam o mesmo plano.

Mudança de contrato: alterações estruturais antes aceitas pela rota XML agora são recusadas explicitamente, sem inferir metadados; devem usar uma operação SDK apropriada, com revisão de seus efeitos. Esta correção NÃO libera nem certifica isolamento de salvamento de Events ou Settings. Os eventos SDK/WorkWithPlus continuam exigindo validação separada.

Validação sem abrir KB:
- 70 testes dirigidos U16 passaram, incluindo conteúdo misto, namespaces, defaults, listas ausentes, identificadores e no-op. Na base pública, esse teste dirigido usou o bypass existente do manifesto U10 somente para compilação/teste offline.
- Na integração com manifestos específicos dos SDKs, Worker U11/U12/U16: 2.556 aprovados e quatro testes de integração ignorados por SDK, gate habilitado e 17 fingerprints conferidos em cada saída.
- Gateway: 1.578 aprovados, 13 ignorados; Hub: 8/8.
- Builds completos nos três SDKs; catálogo dinâmico preservado (54 ferramentas), contratos e diff-check aprovados.

Não houve Save, Apply, Build/Generate de KB, importação ou operação GAM/banco. Testes offline comprovam o planejamento e a recusa; não comprovam persistência real nem ausência de efeitos de terceiros.