### PR TITLE
fix(wwp): preserva nome do objeto no encaminhamento ao Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed WorkWithPlus Settings and instance actions failing to resolve objects by name; preserved explicit identities, pagination and version tokens.
+
 ## v3.2.4 - 2026-09-10
 
 

--- a/src/GxMcp.Gateway.Tests/OperationalCompatibilityContractTests.cs
+++ b/src/GxMcp.Gateway.Tests/OperationalCompatibilityContractTests.cs
@@ -77,6 +77,59 @@ namespace GxMcp.Gateway.Tests
                 ((JArray)control["properties"]!["type"]!["enum"]!).Select(value => value.ToString()));
         }
 
+        [Theory]
+        [InlineData("settings_templates")]
+        [InlineData("settings_read")]
+        [InlineData("settings_edit")]
+        [InlineData("list")]
+        [InlineData("add_action")]
+        public void WorkWithPlusPublishedNameReachesWorkerTarget(string action)
+        {
+            var args = new JObject
+            {
+                ["action"] = action, ["name"] = "WorkWithPlus",
+                ["dryRun"] = true, ["template"] = "Transaction",
+                ["offset"] = 12, ["limit"] = 8,
+                ["baseVersion"] = "base", ["expectedVersion"] = "expected", ["versionToken"] = "token"
+            };
+            AssertWorkWithPlusRoute(args, "WorkWithPlus");
+        }
+
+        [Theory]
+        [InlineData("guid", "11111111-2222-3333-4444-555555555555", false)]
+        [InlineData("entityKey", "11111111-2222-3333-4444-555555555555-1", false)]
+        [InlineData("guid", "11111111-2222-3333-4444-555555555555", true)]
+        [InlineData("entityKey", "11111111-2222-3333-4444-555555555555-1", true)]
+        public void WorkWithPlusKeepsExplicitIdentityForTypedWorkerResolution(string identity, string value, bool withName)
+        {
+            var args = new JObject { ["action"] = "settings_templates", [identity] = value };
+            if (withName) args["name"] = "WorkWithPlus";
+            AssertWorkWithPlusRoute(args, withName ? "WorkWithPlus" : null);
+        }
+
+        private static void AssertWorkWithPlusRoute(JObject args, string? expectedTarget)
+        {
+            // Exercise the published schema and the real tools/call entry point, not only a module router.
+            JObject schema = (JObject)FindTool("genexus_wwp")["inputSchema"]!;
+            Assert.Equal("string", schema["properties"]!["name"]!["type"]!.ToString());
+            GatewayArgsValidator.PrimeCache("genexus_wwp", schema);
+            Assert.True(GatewayArgsValidator.Validate("genexus_wwp", args).Ok);
+            var request = new JObject
+            {
+                ["jsonrpc"] = "2.0", ["id"] = "wwp-routing", ["method"] = "tools/call",
+                ["params"] = new JObject { ["name"] = "genexus_wwp", ["arguments"] = args }
+            };
+            var original = request.DeepClone();
+
+            var routed = JObject.FromObject(McpRouter.ConvertToolCall(request)!);
+
+            Assert.Equal("WwpAction", (string?)routed["module"]);
+            Assert.Equal("Run", (string?)routed["action"]);
+            Assert.Equal(expectedTarget, (string?)routed["target"]);
+            Assert.True(JToken.DeepEquals(args, routed["params"]));
+            Assert.True(JToken.DeepEquals(original, request));
+        }
+
         [Fact]
         public void RecipeDoesNotAdvertiseUnsupportedRunAction()
         {

--- a/src/GxMcp.Gateway/Routers/OperationsRouter.cs
+++ b/src/GxMcp.Gateway/Routers/OperationsRouter.cs
@@ -464,6 +464,7 @@ namespace GxMcp.Gateway.Routers
                     {
                         module = "WwpAction",
                         action = "Run",
+                        target = args?["name"]?.ToString(),
                         @params = args
                     };
 

--- a/src/GxMcp.Worker.Tests/WwpActionServiceTests.cs
+++ b/src/GxMcp.Worker.Tests/WwpActionServiceTests.cs
@@ -8,6 +8,32 @@ namespace GxMcp.Worker.Tests
 {
     public class WwpActionServiceTests
     {
+        [Theory]
+        [InlineData(null, "WorkWithPlus", "WorkWithPlus")]
+        [InlineData("", "WorkWithPlus", "WorkWithPlus")]
+        [InlineData(" ", "WorkWithPlus", "WorkWithPlus")]
+        [InlineData("ExplicitTarget", "OtherName", "ExplicitTarget")]
+        [InlineData("WorkWithPlusOrder", null, "WorkWithPlusOrder")]
+        [InlineData(null, null, null)]
+        public void LegacyEnvelopeResolvesNameWithoutReplacingExplicitTarget(string target, string name, string expected)
+        {
+            var args = new JObject { ["name"] = name, ["guid"] = "11111111-2222-3333-4444-555555555555" };
+            var original = args.DeepClone();
+
+            Assert.Equal(expected, WwpActionService.ResolveTarget(target, args));
+            Assert.True(JToken.DeepEquals(original, args));
+        }
+
+        [Fact]
+        public void MissingEnvelopeAndNameKeepIdentityOnlyResolutionAvailable()
+        {
+            Assert.Null(WwpActionService.ResolveTarget(null, null));
+            Assert.Null(WwpActionService.ResolveTarget(null, new JObject
+            {
+                ["entityKey"] = "11111111-2222-3333-4444-555555555555-1"
+            }));
+        }
+
         [Fact]
         public void AddGridAction_WritesTypedAttributesAndNeverAddsSecurity()
         {

--- a/src/GxMcp.Worker/Services/WwpActionService.cs
+++ b/src/GxMcp.Worker/Services/WwpActionService.cs
@@ -26,8 +26,13 @@ namespace GxMcp.Worker.Services
             _write = write;
         }
 
+        // Older gateway envelopes kept the name only inside params.
+        internal static string ResolveTarget(string target, JObject args) =>
+            !string.IsNullOrWhiteSpace(target) ? target : (string)args?["name"];
+
         public string Run(string target, JObject args)
         {
+            target = ResolveTarget(target, args);
             if (((string)args?["action"])?.StartsWith("settings_", StringComparison.Ordinal) == true)
                 return new PatternSettingsService(_objects).Run(target, args);
             try


### PR DESCRIPTION
Chamadas como `genexus_wwp({"action":"settings_templates","name":"WorkWithPlus"})` perdiam o nome no encaminhamento ao Worker: o schema aceitava `name`, mas o Gateway enviava somente `params`, enquanto o dispatcher lia a identidade em `target`. Isso podia resultar em `PatternSettingsNotFound` mesmo com o Settings existente.

O Gateway agora preenche `target` com `name`. O Worker também recupera `params.name` quando recebe um envelope antigo sem alvo, preservando um `target` explícito. GUID, EntityKey, paginação e os aliases de token continuam nos argumentos originais. A mudança trata o encaminhamento; o catálogo de templates e as regras de salvamento não são alterados.

Validação sobre `origin/main` em `fe843ce9` (v3.2.4):

- 16 novos casos de regressão: schema publicado → `tools/call` → envelope, identidades explícitas, preservação dos argumentos e compatibilidade com envelopes antigos.
- Gateway completo: 1582 testes passaram; 13 testes de integração ignorados.
- Worker completo: 2537 testes passaram; 4 testes de integração ignorados.
- CLI: 110 testes passaram; lint passou.
- Metadados da versão, contratos das ferramentas, avaliações/planos v3, manifesto de warnings e `git diff --check` passaram.

Os testes do Worker foram executados offline com GeneXus 18 U16. Como o manifesto padrão upstream fixa U10, essa compilação de testes usou a opção existente `GxMcpSkipSdkValidation=true`; as 17 assemblies U16 foram verificadas separadamente. Nenhum manifesto foi alterado e nenhuma KB foi aberta. A análise `ripwire` não foi executada porque a ferramenta não está instalada.