### PR TITLE
fix(worker): alinhar compatibilidade do SDK à versão principal do GeneXus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- Preserve the last certified search-index snapshot during forced rebuilds so a Worker crash can warm-start from the previous index instead of leaving the KB cold; allow only manifest-declared SDK patch drift within the same major/minor line while retaining exact-build fingerprints otherwise.
+- Validate SDK compatibility by GeneXus major at build and startup. Report minor, patch, build and fingerprint drift without rejecting a supported major, including changed DLLs with the same ProductVersion; retain failures for missing required assemblies and different or unreadable majors.
+- Preserve the last certified search-index snapshot during forced rebuilds so a Worker crash can warm-start from the previous index instead of leaving the KB cold.
 - Keep the index-readiness fast-fail limited to index-backed reads and analyses; SDK edits, creates and builds remain available while background indexing runs.
 - Never store `Indexing`/`IndexNotReady` responses in the semantic cache, so reads can observe the index as soon as background indexing completes.
 - Make Worker drain replacement fail closed until the old process has really exited; do not register dead replacements, leak draining entries, or run concurrent reloads for one KB.

--- a/docs/sdk-compatibility.md
+++ b/docs/sdk-compatibility.md
@@ -1,10 +1,12 @@
 # GeneXus SDK compatibility
 
-The Worker is compiled against the GeneXus 18 SDK installed on the build host. The SDK is proprietary and is intentionally **not** a NuGet dependency, checked into this repository, or copied into the npm/package artifacts.
+The Worker is compiled against the selected supported GeneXus major installed on the build host. The SDK is proprietary and is intentionally **not** a NuGet dependency, checked into this repository, or copied into the npm/package artifacts.
 
 ## Supported fixture
 
-`config/sdk-compatibility.json` is a public compatibility lock. It records the supported GeneXus product version and SHA-256 fingerprints for the assemblies the Worker references. It contains no SDK bytes or credentials. The current lock was produced from a self-hosted GeneXus 18 installation whose anchor product version is `18.0.10.184260`.
+`config/sdk-compatibility.json` records a reference GeneXus product version and SHA-256 fingerprints for selected assemblies the Worker references. The reference version selects the Worker major; minor, patch, build and hash differences within that major are diagnostics, not compatibility failures. The manifest contains no SDK bytes or credentials. The default reference was produced from a self-hosted GeneXus 18 installation whose anchor product version is `18.0.10.184260`.
+
+Both build and startup require the reference GeneXus major and all listed assemblies. The legacy `allowPatchVersionDrift` flag is no longer consulted: compatibility within the supported major does not require an opt-in. Fingerprint drift is reported even when ProductVersion is unchanged. These checks establish SDK compatibility, not validation of KB writes or save-event isolation.
 
 Provide the SDK through a self-hosted Windows build image or an installed developer workstation:
 
@@ -17,9 +19,10 @@ The build target runs `scripts/validate-gx-sdk.ps1` before resolving references.
 
 - `GXMCP_SDK_PATH_MISSING`
 - `GXMCP_SDK_VERSION_MISMATCH`
-- `GXMCP_SDK_FINGERPRINT_MISMATCH`
+- `GXMCP_SDK_ASSEMBLY_MISSING`
+- `GXMCP_SDK_FINGERPRINT_DRIFT` (informational; compatibility still succeeds)
 
-A mismatch is a failed build/startup, not a best-effort warning. To inspect the exact path and expected lock, run:
+A missing required assembly or different/unreadable major fails build/startup. A different major requires a Worker built and validated for that major; changing the manifest on an existing binary is not an upgrade path. To inspect the selected SDK and reference, run:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
@@ -30,4 +33,4 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 
 Do not publish proprietary DLLs, secrets, or a copied SDK fixture in CI. A CI runner without the self-hosted SDK should report the SDK build/live gate as unavailable; it must not claim that the Worker build passed.
 
-When intentionally upgrading the supported SDK, install the candidate on a controlled self-hosted image, run the validator, update the manifest hashes and version together, then run the focused tests and full verification gates. Treat the manifest as a reviewable compatibility decision, not as a license to redistribute the SDK.
+When upgrading within a supported major, run the validator, focused compatibility tests and the authorized live smoke. Refresh reference hashes when useful for diagnosis; exact hashes are not an acceptance gate. Adding a major also requires the explicit version catalog entry and a Worker built and live-tested for it. Package hashes still protect the integrity of our distributed binaries and rollback files; they are separate from SDK compatibility.

--- a/scripts/tests/sdk-validation-contract.tests.ps1
+++ b/scripts/tests/sdk-validation-contract.tests.ps1
@@ -40,9 +40,46 @@ try {
     $status = Get-Content -LiteralPath $statusPath -Raw | ConvertFrom-Json
     if ($status.state -ne 'fail') { throw "Expected fail state, got $($status.state)." }
     if (@(Get-ChildItem -LiteralPath $outputRoot -Filter 'run-*' -Directory).Count -ne 0) { throw 'Run directory was not cleaned after failure.' }
+
+    # A copy of the test host's PE exercises the real validator without any GeneXus DLL or KB.
+    $anchor = Join-Path $sdk 'Artech.Architecture.Common.dll'
+    Copy-Item -LiteralPath ([System.Management.Automation.PSObject].Assembly.Location) -Destination $anchor
+    $fixtureVersion = [Diagnostics.FileVersionInfo]::GetVersionInfo($anchor).ProductVersion
+    $fixtureMajor = [int]($fixtureVersion -split '\.')[0]
+    $compatManifest = Join-Path $outputRoot 'sdk-compatibility.json'
+    $spec = @{
+        supportedVersion = $fixtureVersion
+        anchor = 'Artech.Architecture.Common.dll'
+        assemblies = @(@{ path = 'Artech.Architecture.Common.dll'; sha256 = (Get-FileHash -LiteralPath $anchor -Algorithm SHA256).Hash })
+    }
+    $validator = Join-Path $PSScriptRoot '../validate-gx-sdk.ps1'
+    function Assert-SdkValidation([int]$exitCode, [string]$diagnostic) {
+        $spec | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $compatManifest -Encoding utf8
+        $output = & powershell.exe -NoProfile -File $validator -GxPath $sdk -Manifest $compatManifest 2>&1 | Out-String
+        if ($LASTEXITCODE -ne $exitCode -or -not $output.Contains($diagnostic)) {
+            throw "SDK validator expected exit=$exitCode and '$diagnostic', got exit=$LASTEXITCODE`: $output"
+        }
+    }
+    Assert-SdkValidation 0 'GXMCP_SDK_COMPATIBLE'
+    $spec.assemblies[0].sha256 = '0' * 64
+    Assert-SdkValidation 0 'GXMCP_SDK_FINGERPRINT_DRIFT'
+    $spec.supportedVersion = "$fixtureMajor.0.10.184260"
+    Assert-SdkValidation 0 'compatible major; patch/build drift'
+    $spec.allowPatchVersionDrift = $false
+    $spec.supportedVersion = "$fixtureMajor.1.0.0"
+    Assert-SdkValidation 0 'GXMCP_SDK_COMPATIBLE'
+    $spec.supportedVersion = "$($fixtureMajor + 1).0.16.189550"
+    Assert-SdkValidation 1 'GXMCP_SDK_VERSION_MISMATCH'
+    $spec.supportedVersion = 'invalid'
+    Assert-SdkValidation 1 'GXMCP_SDK_VERSION_MISMATCH'
+    $spec.supportedVersion = $fixtureVersion
+    $spec.assemblies[0].path = 'missing-required.dll'
+    Assert-SdkValidation 1 'GXMCP_SDK_ASSEMBLY_MISSING'
+    $spec.assemblies = @()
+    Assert-SdkValidation 1 'GXMCP_SDK_MANIFEST_INVALID'
 }
 finally {
     $env:GXMCP_SDK_CI_LICENSE_ACK = $oldAck
     Remove-Item -LiteralPath $outputRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
-Write-Host 'PASS: SDK lane syntax, explicit pass/skip/fail states, preconditions, status artifact, and cleanup contract.'
+Write-Host 'PASS: SDK lane syntax, pass/skip/fail states, cleanup, and 8 no-KB build-validator major/fingerprint/required-assembly cases.'

--- a/scripts/validate-gx-sdk.ps1
+++ b/scripts/validate-gx-sdk.ps1
@@ -23,12 +23,17 @@ if (-not (Test-Path -LiteralPath $anchor -PathType Leaf)) {
     Fail "GXMCP_SDK_ANCHOR_MISSING path=$($spec.anchor)"
 }
 $actualVersion = [Diagnostics.FileVersionInfo]::GetVersionInfo($anchor).ProductVersion
-$expectedParts = $spec.supportedVersion.Split('.')
-$actualParts = $actualVersion.Split('.')
-$sameMajorMinor = $expectedParts.Count -ge 2 -and $actualParts.Count -ge 2 -and $expectedParts[0] -eq $actualParts[0] -and $expectedParts[1] -eq $actualParts[1]
+$expectedMajor = 0
+$actualMajor = 0
+$sameMajor = [int]::TryParse(([string]$spec.supportedVersion -split '\.')[0], [ref]$expectedMajor) -and
+    [int]::TryParse(([string]$actualVersion -split '\.')[0], [ref]$actualMajor) -and
+    $expectedMajor -gt 0 -and $expectedMajor -eq $actualMajor
 $exactVersion = $actualVersion -eq $spec.supportedVersion
-if (-not $exactVersion -and -not ($spec.allowPatchVersionDrift -and $sameMajorMinor)) {
+if (-not $sameMajor) {
     Fail "GXMCP_SDK_VERSION_MISMATCH expectedVersion=$($spec.supportedVersion) actualVersion=$actualVersion"
+}
+if (-not $spec.assemblies -or $spec.assemblies.Count -eq 0) {
+    Fail "GXMCP_SDK_MANIFEST_INVALID manifest=$Manifest error=assemblies"
 }
 foreach ($assembly in $spec.assemblies) {
     $file = Join-Path $GxPath $assembly.path
@@ -41,10 +46,10 @@ foreach ($assembly in $spec.assemblies) {
         $actualHash = ([BitConverter]::ToString($sha.ComputeHash($bytes))).Replace('-', '').ToLowerInvariant()
     }
     finally { $sha.Dispose() }
-    if ($exactVersion -and $actualHash -ne $assembly.sha256.ToLowerInvariant()) {
-        Fail "GXMCP_SDK_FINGERPRINT_MISMATCH path=$($assembly.path) expectedSha256=$($assembly.sha256) actualSha256=$actualHash"
+    if ($actualHash -ne $assembly.sha256) {
+        Write-Output "GXMCP_SDK_FINGERPRINT_DRIFT path=$($assembly.path) expectedSha256=$($assembly.sha256) actualSha256=$actualHash"
     }
 }
-if ($exactVersion) { $versionDiagnostic = $spec.supportedVersion } else { $versionDiagnostic = "$($spec.supportedVersion) actualVersion=$actualVersion (compatible patch drift)" }
+if ($exactVersion) { $versionDiagnostic = $spec.supportedVersion } else { $versionDiagnostic = "$($spec.supportedVersion) actualVersion=$actualVersion (compatible major; patch/build drift)" }
 Write-Output "GXMCP_SDK_COMPATIBLE version=$versionDiagnostic assemblies=$($spec.assemblies.Count)"
 exit 0

--- a/src/GxMcp.Worker.Tests/SdkCompatibilityValidatorTests.cs
+++ b/src/GxMcp.Worker.Tests/SdkCompatibilityValidatorTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
-using System.Text;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -9,6 +8,24 @@ namespace GxMcp.Worker.Tests
 {
     public class SdkCompatibilityValidatorTests
     {
+        [Theory]
+        [InlineData("18.0.10.184260")]
+        [InlineData("18.0.11.185416+build11")]
+        [InlineData("18.0.12.186073+build12")]
+        [InlineData("18.0.16.189550+build16")]
+        public void SelectedManifest_AllowsSameMajorDriftAndReportsChangedFingerprints(string version)
+        {
+            using (var fixture = new SdkFixture(version, "selected-sdk"))
+            {
+                Assert.True(SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version).IsCompatible);
+                Assert.True(SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version + "-different").IsCompatible);
+                File.WriteAllText(Path.Combine(fixture.Root, "Artech.Architecture.Common.dll"), "different-sdk-bytes");
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version);
+                Assert.True(result.IsCompatible);
+                Assert.Contains("GXMCP_SDK_FINGERPRINT_DRIFT", result.Diagnostic);
+            }
+        }
+
         [Fact]
         public void Validate_ReturnsCompatibleForMatchingVersionAndFingerprint()
         {
@@ -22,15 +39,16 @@ namespace GxMcp.Worker.Tests
         }
 
         [Fact]
-        public void Validate_RejectsFingerprintMismatchWithStableDiagnostic()
+        public void Validate_ReportsFingerprintDriftWithTheSameProductVersionWithoutBlocking()
         {
             using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
             {
                 File.WriteAllText(Path.Combine(fixture.Root, "Artech.Architecture.Common.dll"), "tampered");
                 var result = GxMcp.Worker.SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.10.184260");
 
-                Assert.False(result.IsCompatible);
-                Assert.Equal("GXMCP_SDK_FINGERPRINT_MISMATCH", result.Code);
+                Assert.True(result.IsCompatible);
+                Assert.Equal("GXMCP_SDK_COMPATIBLE", result.Code);
+                Assert.Contains("GXMCP_SDK_FINGERPRINT_DRIFT", result.Diagnostic);
                 Assert.Contains("expectedSha256=", result.Diagnostic);
                 Assert.Contains("actualSha256=", result.Diagnostic);
             }
@@ -48,43 +66,84 @@ namespace GxMcp.Worker.Tests
             Assert.Equal("GXMCP_SDK_PATH_MISSING path=<missing>", result.Diagnostic);
         }
 
-        [Fact]
-        public void Validate_ReportsVersionMismatchBeforeAssemblyDetails()
-        {
-            using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
-            {
-                File.WriteAllText(fixture.Manifest, File.ReadAllText(fixture.Manifest).Replace("18.0.10.184260", "18.0.9.0"));
-                var result = GxMcp.Worker.SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.10.184260");
-
-                Assert.False(result.IsCompatible);
-                Assert.Equal("GXMCP_SDK_VERSION_MISMATCH", result.Code);
-                Assert.Contains("expectedVersion=18.0.9.0", result.Diagnostic);
-                Assert.Contains("actualVersion=18.0.10.184260", result.Diagnostic);
-            }
-        }
-
-        [Fact]
-        public void Validate_AllowsDeclaredPatchDriftWithinSameMajorMinor()
+        [Theory]
+        [InlineData("17.0.10.184260")]
+        [InlineData("19.0.10.184260")]
+        [InlineData("invalid")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Validate_RejectsDifferentOrUnreadableMajorBeforeAssemblyDetails(string actualVersion)
         {
             using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
             {
                 var json = JObject.Parse(File.ReadAllText(fixture.Manifest));
-                json["allowPatchVersionDrift"] = true;
+                json["assemblies"] = new JArray();
                 File.WriteAllText(fixture.Manifest, json.ToString());
-                var result = GxMcp.Worker.SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.14.187794");
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => actualVersion);
+
+                Assert.False(result.IsCompatible);
+                Assert.Equal("GXMCP_SDK_VERSION_MISMATCH", result.Code);
+                Assert.Contains("expectedVersion=18.0.10.184260", result.Diagnostic);
+                Assert.Contains("actualVersion=" + actualVersion, result.Diagnostic);
+            }
+        }
+
+        [Theory]
+        [InlineData("18.0.14.187794", true)]
+        [InlineData("18.0.16.189550+build16", false)]
+        [InlineData("18.1.0.0", false)]
+        public void Validate_AllowsSameMajorDriftRegardlessOfLegacyOptIn(string actualVersion, bool legacyOptIn)
+        {
+            using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
+            {
+                var json = JObject.Parse(File.ReadAllText(fixture.Manifest));
+                json["allowPatchVersionDrift"] = legacyOptIn;
+                File.WriteAllText(fixture.Manifest, json.ToString());
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => actualVersion);
                 Assert.True(result.IsCompatible);
-                Assert.Contains("compatible patch drift", result.Diagnostic);
+                Assert.Contains("compatible major; patch/build drift", result.Diagnostic);
             }
         }
 
         [Fact]
-        public void Validate_RejectsPatchDriftWhenManifestDoesNotOptIn()
+        public void Validate_AllowsPatchDriftWithoutLegacyOptIn()
         {
             using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
             {
                 var result = GxMcp.Worker.SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.14.187794");
+                Assert.True(result.IsCompatible);
+                Assert.Equal("GXMCP_SDK_COMPATIBLE", result.Code);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Validate_RejectsMissingRequiredAssemblyEvenWithCompatibleVersion(bool patchDrift)
+        {
+            using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
+            {
+                var json = JObject.Parse(File.ReadAllText(fixture.Manifest));
+                json["assemblies"][0]["path"] = "missing-required.dll";
+                File.WriteAllText(fixture.Manifest, json.ToString());
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest,
+                    _ => patchDrift ? "18.0.16.189550" : "18.0.10.184260");
                 Assert.False(result.IsCompatible);
-                Assert.Equal("GXMCP_SDK_VERSION_MISMATCH", result.Code);
+                Assert.Equal("GXMCP_SDK_ASSEMBLY_MISSING", result.Code);
+            }
+        }
+
+        [Fact]
+        public void Validate_RejectsManifestWithoutRequiredAssemblies()
+        {
+            using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
+            {
+                var json = JObject.Parse(File.ReadAllText(fixture.Manifest));
+                json["assemblies"] = new JArray();
+                File.WriteAllText(fixture.Manifest, json.ToString());
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.16.189550");
+                Assert.False(result.IsCompatible);
+                Assert.Equal("GXMCP_SDK_MANIFEST_INVALID", result.Code);
             }
         }
 

--- a/src/GxMcp.Worker/SdkCompatibilityValidator.cs
+++ b/src/GxMcp.Worker/SdkCompatibilityValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using Newtonsoft.Json.Linq;
@@ -38,7 +39,6 @@ namespace GxMcp.Worker
             catch (Exception ex) { return Fail("GXMCP_SDK_MANIFEST_INVALID", "GXMCP_SDK_MANIFEST_INVALID manifest=" + manifestPath + " error=" + ex.GetType().Name); }
 
             string expectedVersion = (string)manifest["supportedVersion"];
-            bool allowPatchVersionDrift = manifest["allowPatchVersionDrift"]?.Value<bool>() ?? false;
             string anchor = (string)manifest["anchor"];
             string anchorPath = Path.Combine(sdkPath, anchor ?? string.Empty);
             if (string.IsNullOrWhiteSpace(anchor) || !File.Exists(anchorPath))
@@ -46,13 +46,13 @@ namespace GxMcp.Worker
 
             string actualVersion = versionReader(anchorPath);
             bool exactVersion = string.Equals(expectedVersion, actualVersion, StringComparison.OrdinalIgnoreCase);
-            bool compatiblePatch = allowPatchVersionDrift && SameMajorMinor(expectedVersion, actualVersion);
-            if (!exactVersion && !compatiblePatch)
+            if (!SameMajor(expectedVersion, actualVersion))
                 return Fail("GXMCP_SDK_VERSION_MISMATCH", "GXMCP_SDK_VERSION_MISMATCH expectedVersion=" + expectedVersion + " actualVersion=" + actualVersion);
 
             var assemblies = manifest["assemblies"] as JArray;
             if (assemblies == null || assemblies.Count == 0)
                 return Fail("GXMCP_SDK_MANIFEST_INVALID", "GXMCP_SDK_MANIFEST_INVALID manifest=" + manifestPath + " error=assemblies");
+            var fingerprintDrift = new List<string>();
             foreach (var token in assemblies)
             {
                 string relativePath = (string)token["path"];
@@ -60,22 +60,22 @@ namespace GxMcp.Worker
                 string filePath = Path.Combine(sdkPath, relativePath ?? string.Empty);
                 if (string.IsNullOrWhiteSpace(relativePath) || !File.Exists(filePath))
                     return Fail("GXMCP_SDK_ASSEMBLY_MISSING", "GXMCP_SDK_ASSEMBLY_MISSING path=" + (relativePath ?? "<missing>"));
-                string actualHash = exactVersion ? Sha256(filePath) : null;
-                if (exactVersion && !string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
-                    return Fail("GXMCP_SDK_FINGERPRINT_MISMATCH", "GXMCP_SDK_FINGERPRINT_MISMATCH path=" + relativePath + " expectedSha256=" + expectedHash + " actualSha256=" + actualHash);
+                string actualHash = Sha256(filePath);
+                if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+                    fingerprintDrift.Add("GXMCP_SDK_FINGERPRINT_DRIFT path=" + relativePath + " expectedSha256=" + expectedHash + " actualSha256=" + actualHash);
             }
-            string versionDiagnostic = exactVersion ? expectedVersion : expectedVersion + " actualVersion=" + actualVersion + " (compatible patch drift)";
-            return new SdkCompatibilityResult(true, "GXMCP_SDK_COMPATIBLE", "GXMCP_SDK_COMPATIBLE version=" + versionDiagnostic + " assemblies=" + assemblies.Count);
+            string versionDiagnostic = exactVersion ? expectedVersion : expectedVersion + " actualVersion=" + actualVersion + " (compatible major; patch/build drift)";
+            string diagnostic = "GXMCP_SDK_COMPATIBLE version=" + versionDiagnostic + " assemblies=" + assemblies.Count;
+            if (fingerprintDrift.Count > 0) diagnostic += "\n" + string.Join("\n", fingerprintDrift);
+            return new SdkCompatibilityResult(true, "GXMCP_SDK_COMPATIBLE", diagnostic);
         }
 
-        private static bool SameMajorMinor(string expected, string actual)
+        private static bool SameMajor(string expected, string actual)
         {
             if (string.IsNullOrWhiteSpace(expected) || string.IsNullOrWhiteSpace(actual)) return false;
-            var e = expected.Split('.');
-            var a = actual.Split('.');
-            return e.Length >= 2 && a.Length >= 2
-                && string.Equals(e[0], a[0], StringComparison.Ordinal)
-                && string.Equals(e[1], a[1], StringComparison.Ordinal);
+            return int.TryParse(expected.Split('.')[0], out int expectedMajor)
+                && int.TryParse(actual.Split('.')[0], out int actualMajor)
+                && expectedMajor > 0 && expectedMajor == actualMajor;
         }
 
         private static SdkCompatibilityResult Fail(string code, string diagnostic)


### PR DESCRIPTION
O validador do SDK ainda rejeitava DLLs com hash diferente quando o ProductVersion era igual à referência. Também exigia opt-in para atualizações e igualdade de versão minor, contrariando o contrato de compatibilidade por versão principal do GeneXus.

Esta correção alinha a validação de build e de inicialização do Worker: diferenças de minor, patch, build e SHA-256 são diagnósticas dentro da mesma versão principal. Uma versão principal diferente ou ilegível e a ausência de bibliotecas obrigatórias continuam impedindo a execução. A opção legada allowPatchVersionDrift deixa de controlar a aceitação; o manifesto público continua intacto.

Os testes cobrem hashes diferentes com o mesmo ProductVersion, atualizações com e sem a opção legada, diferença de minor, versão principal incompatível/ilegível e bibliotecas obrigatórias ausentes. O teste PowerShell executa o validador real com um arquivo PE do próprio host de teste, sem distribuir DLLs proprietárias nem abrir uma KB.

A mudança é restrita à compatibilidade do SDK. Não altera persistência, eventos de salvamento, roteamento de tipos, perfis ou seleção de KB/versão. Compatibilidade de carregamento não certifica isolamento de escrita. Os hashes dos pacotes distribuídos continuam adequados para integridade e rollback.

Validação no commit 7c48c90c, sobre main 97bc7e6d: builds U11/U12/U16 e 2.617 testes Worker aprovados em cada SDK; suíte Gateway com cobertura (1.605 aprovados), pisos atendidos com 64,06% Gateway e 48,05% Worker; 114 testes CLI, 111 testes Nexus IDE, lint/compilação, 16 verificações de qualidade e smoke do contrato LLM aprovados. A fixture golden foi validada sem modo de atualização.

Não houve abertura ou escrita em KB: os 4 testes Worker e 13 testes Gateway dependentes de ambiente/fixture ficaram ignorados. Não certificamos persistência ou isolamento SDK com esses resultados. GeneXus 17 não está instalado neste host e não foi ensaiado. A análise ripwire está indisponível; o fluxo de chamada, o diff e a privacidade foram revisados manualmente por revisores independentes.