### PR TITLE
fix(worker): preservar alterações do índice após falha de publicação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Preserved pending index changes after a snapshot publication failure, so a successful retry stores the latest contents instead of certifying stale data.
 - Preserve the last certified search-index snapshot during forced rebuilds so a Worker crash can warm-start from the previous index instead of leaving the KB cold; allow only manifest-declared SDK patch drift within the same major/minor line while retaining exact-build fingerprints otherwise.
 - Keep the index-readiness fast-fail limited to index-backed reads and analyses; SDK edits, creates and builds remain available while background indexing runs.
 - Never store `Indexing`/`IndexNotReady` responses in the semantic cache, so reads can observe the index as soon as background indexing completes.

--- a/src/GxMcp.Worker.Tests/IndexShardingTests.cs
+++ b/src/GxMcp.Worker.Tests/IndexShardingTests.cs
@@ -84,6 +84,67 @@ namespace GxMcp.Worker.Tests
         }
 
         [Fact]
+        public void VersionedSnapshot_FailedPublicationRetriesEveryDirtyShard()
+        {
+            string kbPath = UniqueKbPath();
+            var cache = new IndexCacheService();
+            cache.Initialize(kbPath, proactiveLoad: false);
+            try
+            {
+                var entry = Entry("Procedure", "RetryProbe");
+                entry.Description = "before";
+                cache.ReplaceAll(new[] { entry });
+                Assert.True(cache.FlushNow(), IndexCacheService.LastFlushErrorMessage ?? "no error");
+                string originalPointer = File.ReadAllText(cache.SnapshotPointerPathForTest);
+                long originalGeneration = cache.FlushedGeneration;
+
+                cache.AddOrUpdateBatch(new[] {
+                    new SearchIndex.IndexEntry {
+                        Name = entry.Name, Type = entry.Type, Guid = entry.Guid, Description = "after"
+                    }
+                });
+                using (File.Open(cache.SnapshotPointerPathForTest, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    Assert.False(cache.FlushNow(100));
+                    Assert.False(cache.IsFullyFlushed);
+                    Assert.Equal(originalGeneration, cache.FlushedGeneration);
+                    Assert.Equal(originalPointer, File.ReadAllText(cache.SnapshotPointerPathForTest));
+                }
+
+                Assert.True(cache.FlushNow(), IndexCacheService.LastFlushErrorMessage ?? "no error");
+                Assert.True(cache.IsFullyFlushed);
+                var reloaded = new IndexCacheService();
+                reloaded.Initialize(kbPath, proactiveLoad: false);
+                Assert.Equal("after", reloaded.GetIndex().Objects["Procedure:RetryProbe"].Description);
+            }
+            finally { cache.DeleteOnDiskSnapshot(); }
+        }
+
+        [Fact]
+        public void VersionedSnapshot_NewBodyRequiresItsOwnEnrichmentCertificate()
+        {
+            var cache = new IndexCacheService();
+            cache.Initialize(UniqueKbPath(), proactiveLoad: false);
+            try
+            {
+                cache.ReplaceAll(new[] { Entry("Procedure", "CertifiedBody") });
+                Assert.True(cache.FlushNow(), IndexCacheService.LastFlushErrorMessage ?? "no error");
+                cache.ObserveLastUpdate(DateTime.UtcNow);
+                cache.WriteMetaSidecar(1);
+                Assert.True(cache.ValidateOnDiskCache().CanDelta);
+
+                cache.AddOrUpdateBatch(new[] { Entry("Procedure", "AwaitingEnrichment") });
+                Assert.True(cache.FlushNow(), IndexCacheService.LastFlushErrorMessage ?? "no error");
+                var validation = cache.ValidateOnDiskCache();
+                Assert.True(validation.BodyPresent);
+                Assert.False(validation.MetaPresent);
+                Assert.False(validation.CanDelta);
+                Assert.False(validation.CanDeltaAcrossDll);
+            }
+            finally { cache.DeleteOnDiskSnapshot(); }
+        }
+
+        [Fact]
         public void VersionedSnapshot_IgnoresAbandonedRebuildSlotAndLoadsCertifiedGeneration()
         {
             string kbPath = UniqueKbPath();

--- a/src/GxMcp.Worker/Services/IndexCacheService.cs
+++ b/src/GxMcp.Worker/Services/IndexCacheService.cs
@@ -1783,20 +1783,16 @@ namespace GxMcp.Worker.Services
             finally { try { if (File.Exists(tmp)) File.Delete(tmp); } catch { } }
         }
 
-        // Returns true when this call wrote a snapshot to disk that is at least as new
-        // as the dirty generation captured before serialization started; false when it
-        // skipped (flush already in flight / no index) or failed. Never throws.
-        //
         // Plan 003 (sharded flush): only shards dirtied since the last successful flush
         // are (re)serialized — clean shards are left untouched on disk, so cost scales
         // with dirty-entry count rather than total index size. Each dirty shard id is
         // popped from _dirtyShards BEFORE its content is read/written, so any mutation
         // landing concurrently (even mid-write) re-marks the shard dirty for the next
         // round instead of being silently dropped by an end-of-round clear.
-        private bool FlushVersionedSlot(SearchIndex snapshot, List<int> idsToWrite, long generation)
+        private void FlushVersionedSlot(SearchIndex snapshot, List<int> idsToWrite, long generation)
         {
             string slots = _snapshotSlotsPath;
-            if (string.IsNullOrEmpty(slots)) return false;
+            if (string.IsNullOrEmpty(slots)) throw new InvalidOperationException("Index snapshot path is not initialized.");
             string slotName = "generation-" + generation + "-" + Guid.NewGuid().ToString("N");
             string tempSlot = Path.Combine(slots, ".rebuild-" + Guid.NewGuid().ToString("N"));
             string finalSlot = Path.Combine(slots, slotName);
@@ -1835,6 +1831,8 @@ namespace GxMcp.Worker.Services
                     if (idsToWrite.Contains(id)) _shardWriteCounts.AddOrUpdate(id, 1, (k, v) => v + 1);
                 }
 
+                // Do not inherit the previous generation's enrichment certificate.
+                // Its caller must certify this body with WriteMetaSidecar after enrichment/delta completes.
                 WriteShardManifestAt(tempSlot, snapshot.Objects.Count);
                 Directory.Move(tempSlot, finalSlot);
                 string pointerTemp = _snapshotPointerPath + ".tmp-" + Guid.NewGuid().ToString("N");
@@ -1855,13 +1853,6 @@ namespace GxMcp.Worker.Services
                             Directory.Delete(directory, true);
                 }
                 catch (Exception cleanup) { Logger.Warn("Snapshot slot cleanup deferred: " + cleanup.Message); }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _lastFlushErrorMessage = ex.Message;
-                Logger.Error("Versioned index snapshot failed: " + ex.ToString());
-                return false;
             }
             finally { try { if (Directory.Exists(tempSlot)) Directory.Delete(tempSlot, true); } catch { } }
         }
@@ -1879,6 +1870,8 @@ namespace GxMcp.Worker.Services
             File.WriteAllText(Path.Combine(directory, "manifest.json"), Newtonsoft.Json.JsonConvert.SerializeObject(manifest), new UTF8Encoding(false));
         }
 
+        // Returns true only after publishing the captured generation. Failures retain
+        // dirty shards for retry and return false; they never certify the old bytes.
         private bool FlushToDisk()
         {
             if (_savingInProgress) return false;
@@ -1906,7 +1899,7 @@ namespace GxMcp.Worker.Services
 
             try
             {
-                if (!FlushVersionedSlot(snapshot, idsToWrite, gen)) return false;
+                FlushVersionedSlot(snapshot, idsToWrite, gen);
                 System.Threading.Interlocked.Exchange(ref _consecutiveFlushFailures, 0);
                 _lastFlushSuccessUtc = DateTime.UtcNow;
                 _lastFlushErrorMessage = null;
@@ -1917,8 +1910,8 @@ namespace GxMcp.Worker.Services
                 return true;
             }
             catch (Exception ex) {
-                // Round-level failure (e.g. directory creation) before/around the per-shard
-                // loop — restore every popped id so nothing is lost.
+                // Includes failed certified-pointer publication: the old generation is
+                // still current, so every popped shard must be retried with its new bytes.
                 foreach (var id in idsToWrite) _dirtyShards[id] = 1;
                 int n = System.Threading.Interlocked.Increment(ref _consecutiveFlushFailures);
                 _lastFlushErrorMessage = ex.Message;


### PR DESCRIPTION
Uma falha ao substituir o ponteiro do snapshot fazia `FlushVersionedSlot` retornar false depois de `FlushToDisk` retirar os shards pendentes. A tentativa seguinte podia copiar os dados anteriores e marcar a geração nova como persistida.

A exceção agora alcança o tratamento existente de `FlushToDisk`, que recoloca todos os shards pendentes. O teste bloqueia a substituição do arquivo de verdade, confirma que ponteiro e geração não avançam e verifica a alteração por uma nova instância do cache após a repetição. Antes da correção, esse teste falhou com valor anterior mesmo após `FlushNow=true` e `IsFullyFlushed=true`.

Uma nova geração continua exigindo seu próprio certificado de enriquecimento; o teste adicional documenta a invalidação conservadora do sidecar. Não há cópia de um certificado antigo para um corpo parcial. A correção não muda contratos MCP nem acessa objetos da KB.

Validação direcionada: reprodução falha antes da correção; 14/14 testes de sharding e 34/34 testes de flush, metadados e snapshots aprovados depois. CI completo no commit b3f5ee44: build U16 e 2.606 testes Worker; 1.605 testes Gateway; cobertura de 63,89% Gateway e 48,07% Worker, acima dos pisos de 60%/45%; 114 testes CLI, 111 testes Nexus IDE, lint/compilação, 16 verificações de qualidade e smoke LLM aprovados. Golden validado sem atualização. Os 4 testes Worker e 13 testes Gateway dependentes de ambiente/fixture ficaram ignorados. O manifesto U16 foi fornecido como configuração temporária do ensaio, validando 17 assemblies sem bypass, e os bytes originais foram restaurados antes e depois; nenhum manifesto integra o PR. Os ensaios usam somente arquivos temporários de cache. Nenhuma KB foi aberta ou modificada.