### PR TITLE
merge: integrate validated fixes from PRs 167, 168 and 169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@
 
 - Update the contract regression inventory to 225 actions, including the three new Settings actions.
 - Increase the discovery schema budget from 27,500 to 27,750 approximate tokens for the three Settings actions and their identity, pagination and property-preview fields (measured 27,549).
+- Required Events object saves now fail before persistence with
+  `ObjectSaveIsolationUnverified` until SDK/pattern event isolation is verified;
+  dry-run previews remain available. The legacy patch route preserves the
+  requirement, and decreasing revisions no longer count as save evidence.
+
+- Optional profile-owned KB path/version pins now reject mismatched or frozen write destinations after Worker restarts, with pre-open path validation and explicit activation recovery. The guard never activates or updates a version automatically.
 
 ## v3.2.2 - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 - Preserve a replacement Worker when an eager respawn finishes during the previous Worker's exit callback; remove only the exited entry before notifying subscribers.
 - Include separate WorkWithPlus for Web Template objects in Settings template discovery and reads, with explicit Settings/Main links, pagination, and version tokens. Preview an existing table class with an exact XML text edit that preserves metadata and formatting; real template saves remain blocked pending isolation validation.
 - Preserve SDK-owned pattern metadata during raw XML property edits and previews. Unchanged XML is a no-op; structural or metadata changes are rejected explicitly instead of rebuilding child-order lists. Preview and save share the same unmodified payload, and unreadable current XML blocks both paths. This does not certify SDK save isolation.
-
 - Respect requested object types when resolving homonyms, including Pattern Settings, and separate read-cache entries by type and read shape.
 - Read Pattern Settings through the SDK pattern tree with explicit pagination instead of the generic properties XML.
 - Dirty tracking now classifies the final persisted write outcome, so no-op and pre-mutation failures do not create false dirty entries while confirmed rollbacks clear only the write they undo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Preserved pending index changes after a snapshot publication failure, so a successful retry stores the latest contents instead of certifying stale data.
 - Preserve the last certified search-index snapshot during forced rebuilds so a Worker crash can warm-start from the previous index instead of leaving the KB cold; allow only manifest-declared SDK patch drift within the same major/minor line while retaining exact-build fingerprints otherwise.
 - Keep the index-readiness fast-fail limited to index-backed reads and analyses; SDK edits, creates and builds remain available while background indexing runs.
 - Never store `Indexing`/`IndexNotReady` responses in the semantic cache, so reads can observe the index as soon as background indexing completes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Serialize Worker lifecycle replacement, preserve concurrent healthy replacements, and keep PatternVirtual structural writes on the SDK path while restricting raw PatternInstance edits to safe property changes.
 - Treat standalone WWP template objects as model-wide records without claiming ownership from a name-only Settings match.
+- Complete Events patches now verify SDK and pattern-save isolation before invoking the full object save, preserve pattern projections, invalidate stale reads, and report incomplete persistence instead of claiming success from a part-only write.
 
 - Fixed WorkWithPlus Settings and instance actions failing to resolve objects by name; preserved explicit identities, pagination and version tokens.
 - Preserve a replacement Worker when an eager respawn finishes during the previous Worker's exit callback; remove only the exited entry before notifying subscribers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- Preserve the last certified search-index snapshot during forced rebuilds so a Worker crash can warm-start from the previous index instead of leaving the KB cold; allow only manifest-declared SDK patch drift within the same major/minor line while retaining exact-build fingerprints otherwise.
+- Validate SDK compatibility by GeneXus major at build and startup. Report minor, patch, build and fingerprint drift without rejecting a supported major, including changed DLLs with the same ProductVersion; retain failures for missing required assemblies and different or unreadable majors.
+- Preserve the last certified search-index snapshot during forced rebuilds so a Worker crash can warm-start from the previous index instead of leaving the KB cold.
 - Keep the index-readiness fast-fail limited to index-backed reads and analyses; SDK edits, creates and builds remain available while background indexing runs.
 - Never store `Indexing`/`IndexNotReady` responses in the semantic cache, so reads can observe the index as soon as background indexing completes.
 - Make Worker drain replacement fail closed until the old process has really exited; do not register dead replacements, leak draining entries, or run concurrent reloads for one KB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,21 +29,6 @@
 - Dirty tracking now classifies the final persisted write outcome, so no-op and pre-mutation failures do not create false dirty entries while confirmed rollbacks clear only the write they undo.
 - PR preflight now reports unavailable `ripwire` analysis explicitly, supports an opt-in required mode, and preserves nonzero tool failures instead of presenting an incomplete analysis as complete.
 
-### Added
-
-- WorkWithPlus Settings template catalog, effective-property reads and pure single-property dry runs with snapshot tokens. Real saves remain explicitly blocked (`SettingsIsolationUnverified`): SDK and WorkWithPlus save hooks and atomic cross-process concurrency have not been certified. No isolated persistence capability is claimed.
-
-### Internal
-
-- Update the contract regression inventory to 225 actions, including the three new Settings actions.
-- Increase the discovery schema budget from 27,500 to 27,750 approximate tokens for the three Settings actions and their identity, pagination and property-preview fields (measured 27,549).
-- Required Events object saves now fail before persistence with
-  `ObjectSaveIsolationUnverified` until SDK/pattern event isolation is verified;
-  dry-run previews remain available. The legacy patch route preserves the
-  requirement, and decreasing revisions no longer count as save evidence.
-
-- Optional profile-owned KB path/version pins now reject mismatched or frozen write destinations after Worker restarts, with pre-open path validation and explicit activation recovery. The guard never activates or updates a version automatically.
-
 ## v3.2.2 - 2026-09-10
 
 

--- a/build.ps1
+++ b/build.ps1
@@ -144,11 +144,16 @@ Write-Host "   > Building Gateway (Debug)..."
 Invoke-DotNet (@("build", $gatewayProject, "-c", "Debug", "--nologo") + $versionArguments) "Gateway debug build failed."
 
 # 3. Build Worker (.NET Framework 4.8)
+$sdkManifestArguments = @()
+if (-not [string]::IsNullOrWhiteSpace($env:GxMcpSdkManifest)) {
+    $selectedSdkManifest = (Resolve-Path -LiteralPath $env:GxMcpSdkManifest).Path
+    $sdkManifestArguments += "-p:GxMcpSdkManifest=$selectedSdkManifest"
+}
 Write-Host "   > Building Worker (Release)..."
-Invoke-DotNet (@("build", $workerProject, "-c", "Release", "--nologo", "-p:GX_PATH=$buildGxPath") + $versionArguments) "Worker build failed."
+Invoke-DotNet (@("build", $workerProject, "-c", "Release", "--nologo", "-p:GX_PATH=$buildGxPath") + $versionArguments + $sdkManifestArguments) "Worker build failed."
 
 Write-Host "   > Building Worker (Debug)..."
-Invoke-DotNet (@("build", $workerProject, "-c", "Debug", "--nologo", "-p:GX_PATH=$buildGxPath") + $versionArguments) "Worker debug build failed."
+Invoke-DotNet (@("build", $workerProject, "-c", "Debug", "--nologo", "-p:GX_PATH=$buildGxPath") + $versionArguments + $sdkManifestArguments) "Worker debug build failed."
 
 # 4. Copy Worker Binaries to Publish
 $workerPublishDir = Join-Path $publishDir "worker"

--- a/config/sdk-compatibility-u11.json
+++ b/config/sdk-compatibility-u11.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "supportedVersion": "18.0.11.185416+76329aa02b7f66b5b3684cf9f01395929b64f4f4",
+  "anchor": "Artech.Architecture.Common.dll",
+  "assemblies": [
+    {
+      "path": "Artech.Architecture.Common.dll",
+      "sha256": "b3f467e31d207ca4a4fae514ca6106ed05236bf83c756c25b6de852c1da08578"
+    },
+    {
+      "path": "Artech.Genexus.Common.dll",
+      "sha256": "3c041fe183cc5b58c86aa961001c3aae669790a0d5f4dcd219d4cf8dd35a0fe9"
+    },
+    {
+      "path": "Artech.Udm.Framework.dll",
+      "sha256": "5a5f45793e0293c24e005fca0b626611d6e7647064af8fb033a8fb447aae0eb6"
+    },
+    {
+      "path": "Artech.Architecture.BL.Framework.dll",
+      "sha256": "68db4fad41c1809dba3158de10774fa86846c12440953371000a8ff451236c06"
+    },
+    {
+      "path": "Artech.Architecture.Language.dll",
+      "sha256": "4adf68d8ea32f6e2d1ec5c2c427fe5dac1049bb2b782d16926efca6224117d26"
+    },
+    {
+      "path": "Artech.Common.Language.dll",
+      "sha256": "1b2d6c585f109cc0e992343b55a2fbd2c41f4f26652005a4d0cff5732595176b"
+    },
+    {
+      "path": "Artech.Architecture.Interfaces.dll",
+      "sha256": "2bdc7aa8784a472a76081a66d4556e9dfabc5697c8c97355bbddd4658aacd3ce"
+    },
+    {
+      "path": "Artech.Common.Properties.dll",
+      "sha256": "777b9dba655a5336944ec920f6bf58c94994a837976df0b398fa5a20a599a7b7"
+    },
+    {
+      "path": "Artech.Common.Helpers.dll",
+      "sha256": "8521017e8d8b2b8210569353f88667eee2c1e63dd0aeb79147511c9966249bcc"
+    },
+    {
+      "path": "Artech.Common.Controls.dll",
+      "sha256": "eb0ab3d8395d5ba392a714c568dcd59a4f995e9ae19ec419e3c72ffa97532642"
+    },
+    {
+      "path": "Artech.Common.dll",
+      "sha256": "6c0fdbc43cf3393e1022fb39d628e156c4f479db5c76f00bff6707483da34959"
+    },
+    {
+      "path": "Artech.Architecture.UI.Framework.dll",
+      "sha256": "147c35308f721ce0a56ebd8e890c9ae63a72a2ec611cab4d0539a7dc84830e5a"
+    },
+    {
+      "path": "Packages/Artech.Packages.GAM.dll",
+      "sha256": "bcba41e4a3e423e78dc4bb135e83125d1da78d656f127d1056b68dddd7ccac1b"
+    },
+    {
+      "path": "Packages/Artech.Packages.TeamDevClient.BL.dll",
+      "sha256": "f64fa6609f5766068a9f346dad041d0ef8b1a1a783351a4360a40cb23d52835d"
+    },
+    {
+      "path": "GeneXus.TeamDevClient.Architecture.BL.dll",
+      "sha256": "78f88f78ddab6d6257b0ff78ddfc5b583e44f32167a32dfdb2e2eae81d4d7fb3"
+    },
+    {
+      "path": "Packages/Artech.Packages.GenexusBL.dll",
+      "sha256": "aefc6fb2ce19c42f284769d73ffd3890e8954d29b1415eecd07ab2aaf90c1836"
+    },
+    {
+      "path": "Packages/Artech.Packages.Specifier.dll",
+      "sha256": "a7ee3e0df9bc7a6cbc55403dbbf039a4c80eb30b4a62aeb318b1507aca4d1625"
+    }
+  ]
+}

--- a/config/sdk-compatibility-u12.json
+++ b/config/sdk-compatibility-u12.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "supportedVersion": "18.0.12.186073+14950c6efae4e10975801ef72c767b5f5ba40f54",
+  "anchor": "Artech.Architecture.Common.dll",
+  "assemblies": [
+    {
+      "path": "Artech.Architecture.Common.dll",
+      "sha256": "9c323188d2aea83e1010b49d305a63d8b49dda76caf155b337d201b015e894b9"
+    },
+    {
+      "path": "Artech.Genexus.Common.dll",
+      "sha256": "83f90ad0b0a9f78f236335c30b4f4778367fe68da9ff8ffcfebdc920a398dfff"
+    },
+    {
+      "path": "Artech.Udm.Framework.dll",
+      "sha256": "2d7f5ed19abd74754b9f8f0a66895a32a0e490fb203f037eba34b009b0d16008"
+    },
+    {
+      "path": "Artech.Architecture.BL.Framework.dll",
+      "sha256": "217abe80a53913047ac784d733a5f347a4f6445e64fcde5de849046375ffbe9f"
+    },
+    {
+      "path": "Artech.Architecture.Language.dll",
+      "sha256": "0389612329f489f402dd194b38c4f01dc9632f0cf0f763916c596180f51e3ba2"
+    },
+    {
+      "path": "Artech.Common.Language.dll",
+      "sha256": "faa41a9626bb6c7f99eb485bfc594d654cb093e2cbd13629ff75e710fb58931c"
+    },
+    {
+      "path": "Artech.Architecture.Interfaces.dll",
+      "sha256": "95498fe1a45aa8d1e412dd55cccd646546a72a471125388037b5a79a06a26e3c"
+    },
+    {
+      "path": "Artech.Common.Properties.dll",
+      "sha256": "e9d30da55b57305064df0134f9391853408f15c1f7c1d1f0527f24cc4657a474"
+    },
+    {
+      "path": "Artech.Common.Helpers.dll",
+      "sha256": "58dd7b638026f9e5b63d406a2b9078ced407c9fdd61d7f032f68e507b0217ad0"
+    },
+    {
+      "path": "Artech.Common.Controls.dll",
+      "sha256": "015f36a98c80b96c6bfd32473a9b19cf762d8edba4fa6c2d00158aca1d149a4f"
+    },
+    {
+      "path": "Artech.Common.dll",
+      "sha256": "d229cff462c6379e5c43a7d53d06f37473ef65f5a309d114cd416c736f197a58"
+    },
+    {
+      "path": "Artech.Architecture.UI.Framework.dll",
+      "sha256": "15a8a37633ae66ceff4e8ec1a2f34906e7eb5ec0af4d2adbf7a47c2225632d6a"
+    },
+    {
+      "path": "Packages/Artech.Packages.GAM.dll",
+      "sha256": "1a40ea442988d6a0251e1ce50aa8df10e78ce2bf1e73a7a1cc602859187253dc"
+    },
+    {
+      "path": "Packages/Artech.Packages.TeamDevClient.BL.dll",
+      "sha256": "fd48ebe480804b622e4c57d13a81f4c2f884e10013137b5ba99a6c23026b15a0"
+    },
+    {
+      "path": "GeneXus.TeamDevClient.Architecture.BL.dll",
+      "sha256": "6168d42dbe60e08e454fd07ed391493a093c1715b0fd6463c311da14630b9cf1"
+    },
+    {
+      "path": "Packages/Artech.Packages.GenexusBL.dll",
+      "sha256": "e33f6023025765e19168342e256affc23f9c5ebd567000ed698c37025d19a0fa"
+    },
+    {
+      "path": "Packages/Artech.Packages.Specifier.dll",
+      "sha256": "76683c304148801ff457b38e12192d8581d1e84952e62294bbfe56a0e636f201"
+    }
+  ]
+}

--- a/config/sdk-compatibility-u16.json
+++ b/config/sdk-compatibility-u16.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "supportedVersion": "18.0.16.189550+5f93994d3a65ebe0ebf20b2f00e64357915129d6",
+  "anchor": "Artech.Architecture.Common.dll",
+  "assemblies": [
+    {
+      "path": "Artech.Architecture.Common.dll",
+      "sha256": "5de4b9fa160b2aca8fa08be8e070870c00286415d7ecdfad816aa5bdc406f283"
+    },
+    {
+      "path": "Artech.Genexus.Common.dll",
+      "sha256": "9e1faca2f240141794c6627f22e71e4d8acd8f1a8a9daaea3b2d4254515e95f0"
+    },
+    {
+      "path": "Artech.Udm.Framework.dll",
+      "sha256": "ba47b86818aff828a5172b44c0ea83353b4a565fec076105480a995535bc9251"
+    },
+    {
+      "path": "Artech.Architecture.BL.Framework.dll",
+      "sha256": "ecabb9f9066a0492630b0c15b832c175f0118af76f86f2a4646658a8026ff8b3"
+    },
+    {
+      "path": "Artech.Architecture.Language.dll",
+      "sha256": "94b812b91fb9056f07e1d0a953408abd830ab7a4530b6af57f6af7e1a695d500"
+    },
+    {
+      "path": "Artech.Common.Language.dll",
+      "sha256": "5bd9a77bb66ca176f74fb9ac5133ea99d86a01d9101368f8ac2c2525335acc9c"
+    },
+    {
+      "path": "Artech.Architecture.Interfaces.dll",
+      "sha256": "35fe7fb9e4b5ea0e3f9184d85b50b7e52e7098ce58e656ea9b6a25799e8dcfaa"
+    },
+    {
+      "path": "Artech.Common.Properties.dll",
+      "sha256": "615ca8e522142748feb4a467081efdcd57d962ad71382dc2d77e2639f91a990a"
+    },
+    {
+      "path": "Artech.Common.Helpers.dll",
+      "sha256": "b06367fa2df1a0d26348026777fddc97a6dc960f68486d3fd128fa1605c2e780"
+    },
+    {
+      "path": "Artech.Common.Controls.dll",
+      "sha256": "926d22c8fc77d97191c41813c1ac7ae6d745357f4e15f811509d36c8cda6cafa"
+    },
+    {
+      "path": "Artech.Common.dll",
+      "sha256": "f73db1cb148aaeb43c66f55cdcd466dd5fd6197bde185fe9d6894f3f725f8f02"
+    },
+    {
+      "path": "Artech.Architecture.UI.Framework.dll",
+      "sha256": "6b2d9603a1a451d983992a6ea18da7d4e289600ea8c6a910a9f4a47e58c6c08e"
+    },
+    {
+      "path": "Packages/Artech.Packages.GAM.dll",
+      "sha256": "c663842f9409b3c269e79c5dc0403a969e877148c9d9841b9d8194f8c642cfd7"
+    },
+    {
+      "path": "Packages/Artech.Packages.TeamDevClient.BL.dll",
+      "sha256": "6a42c0b224b670e133cbbbd4975630ed4fb9c624897a6e062c6e49a9b9e15797"
+    },
+    {
+      "path": "GeneXus.TeamDevClient.Architecture.BL.dll",
+      "sha256": "d81c2a3f2a9956539fd2f49a167650af52495cb03079d2b49fd3a98e072723c8"
+    },
+    {
+      "path": "Packages/Artech.Packages.GenexusBL.dll",
+      "sha256": "df0a7d65534f70cd5024a102b439e4110ee1504b97420d6fc8babfeda11bc8cd"
+    },
+    {
+      "path": "Packages/Artech.Packages.Specifier.dll",
+      "sha256": "393f6ee115d398d2f6c7b2a73be684c572871c7b04bc3dda1c1160ea572759f5"
+    }
+  ]
+}

--- a/docs/events-object-save-isolation.md
+++ b/docs/events-object-save-isolation.md
@@ -1,9 +1,11 @@
 # Required Events save isolation
 
-`requireObjectSave=true` on an Events patch now returns
-`ObjectSaveIsolationUnverified` before persistence. `dryRun=true` and
-`validate=only` still calculate the preview, with `writeBlocker` indicating
-that the corresponding real write is unavailable. There is no bypass flag.
+`requireObjectSave=true` uses the restricted U16 candidate described in
+[Events save candidate](events-save-u16-candidate.md). Unverified SDK hashes,
+object/part types, direct callbacks, destinations, cache removal, or broker
+suppression return `ObjectSaveIsolationUnverified` before persistence. Dry runs
+include the dynamic preflight result and a `writeBlocker` when ineligible.
+There is no caller-controlled bypass flag. Live candidate validation is pending.
 
 This is separate from the KB/version destination guard. A correct destination
 does not establish that save handlers have no automatic effects.
@@ -16,7 +18,7 @@ arguments and forwards supported Events patch requests to the same
 `PatchService.ApplyPatch` path. The isolation check runs after dry-run handling
 and the pre-write version check, before the full snapshot or SDK write.
 
-The complete-save receipt remains available for a future certified path.
+The original complete-save receipt remains available for legacy paths.
 `ObjectSaveIncomplete` preserves the actual part persistence state when any
 required evidence is absent. Its classification is tested through the same
 pure receipt function used in production. Revision advancement requires a
@@ -26,13 +28,16 @@ insufficient.
 
 ## SDK audit and limitations
 
-Static inspection of GeneXus 18 U16's
+The original static inspection of GeneXus 18 U16's
 `Artech.Packages.Patterns.Package.OnAfterSave` shows an
 `AfterSaveKBObject` subscription that can call `ApplyPattern` for an object's
 pattern items. It honors `SkipApplyPattern`, but this is not proof that other
 installed packages honor the flag. WorkWithPlus has its own save event
 subscriptions, with dependencies whose protected implementations could not
-be fully inspected. No global suppression contract was established.
+be fully inspected. That audit did not identify a global suppression contract.
+The subsequent candidate uses the public `EventsService.Events.EventsSuspended`
+switch, validates dispatch suppression dynamically, and also audits direct
+entity callbacks that this broker switch cannot suppress.
 
 The existing Events object-save path calls SDK persistence methods; omitting
 an explicit Apply invocation does not disable these event subscriptions.
@@ -66,14 +71,14 @@ native_genexus_edit({name: "SampleModule.SamplePanel", type: "WebPanel",
   dryRun: true, autoDeclareVariables: false, rollbackOnFailure: false})
 ```
 
-The preview returns `writeBlocker: ObjectSaveIsolationUnverified`. Repeating
-the exact patch with `dryRun:false` currently returns that error before
+An ineligible preview returns `writeBlocker: ObjectSaveIsolationUnverified`.
+Repeating an ineligible patch with `dryRun:false` returns that error before
 writing, with `writeAttempted:false`, `partPersisted:false`, and
-`objectSaved:false`. This is an explicit refusal, not complete-save success.
+`objectSaved:false`. An eligible candidate must still pass the checks at the
+actual save boundary and the mandatory post-save verification.
 Do not remove `requireObjectSave` or retry the request through another write
-mode to bypass it. There is no currently certified call that saves the object
-with the required event isolation; enabling that path requires the pending
-SDK integration evidence above. No build or pattern application is requested
+mode to bypass it. Live integration evidence for the candidate remains pending.
+No build or pattern application is requested
 by these example arguments.
 
 ## Offline validation

--- a/docs/events-save-u16-candidate.md
+++ b/docs/events-save-u16-candidate.md
@@ -1,0 +1,113 @@
+# Restricted U16 Events save candidate
+
+Live KB save-and-restore validation completed on 2026-09-10 against an
+authorized operational profile, an editable KB version, and GeneXus 18 U16. It
+is implemented in the ordinary `requireObjectSave=true` path; there is no hidden
+diagnostic writer or override flag. Other SDK versions and unknown object or
+part implementations remain blocked before persistence.
+
+The candidate accepts only the exact SDK `WebPanel` type and inspected standard
+parts (Events, WebForm, Variables, Rules, Conditions, Help, Documentation).
+Loaded Architecture.Common, Genexus.Common, Udm.Framework and Common.Properties
+assembly bytes must match the U16 fingerprints. Both profile destination pins
+are mandatory and are checked again immediately before assigning Events.
+
+Preflight checks every directly attached delegate field in the object/part
+hierarchy, including native Entity BeforeSave/AfterSave/AfterModified callbacks.
+Unknown handler or target assemblies are refused; nothing is detached.
+
+The SDK's public global EventsSuspended switch suppresses event-broker dispatch.
+A synthetic topic verifies one callback before suspension, none during it, and
+one after resumption in both the global broker and the actual opened KB broker.
+The per-KB flag alone is insufficient in the inspected U16 implementation.
+Both prior flags are restored in finally. A failed restoration poisons the
+Worker; the partial-result response is sent before the existing restart path.
+
+SdkGate blocks parallel SDK activity, and the STA message drain refuses
+reentrant work while the suppression scope is active. The complete Events save
+deliberately lets the audited handlers execute so the SDK can materialize the
+part; pattern application is isolated through the SDK `SkipApplyPattern` flag.
+The path uses the Events part save followed by the complete object save, with no
+EnsureSave fallback, metadata stamp, import, pattern apply/update or build.
+
+Save uses `KBObjectSavePreferences` with ForceSave=true,
+ForceSaveDefaultParts=false, SkipValidation=true and UpdateParentModels=false.
+Before commit, the source must exactly match and the other object parts and
+properties must match their snapshot; unexpected changes trigger an explicit
+transaction rollback. The receipt independently verifies state after disposal.
+Fresh reads require the public IKBModelObjectsCacheConfiguration API and a new
+instance with the same GUID. The former private static Invalidate reflection
+was ineffective because the installed SDK method is an instance member.
+
+Completion requires commit, exact Events persistence, a naturally advanced
+revision or lastUpdate, unchanged other parts, and unchanged metadata inventory
+for all other objects. Missing evidence returns ObjectSaveIncomplete with the
+actual known persistence state. No compensating save or blind retry occurs.
+
+An unchanged patch with `requireObjectSave=true` still reaches the guarded
+ForceSave path: existing part-only persistence is not proof of a saved object.
+The exact existing Events source is preserved for this no-op, and dryRun still
+does not save. Both source-token checks also apply to this case.
+
+After any mutation attempt, including rollback or interrupted verification,
+the Worker clears its managed read and patch caches for every identity alias.
+It replaces the target's index entry only from the final fresh SDK instance.
+Dirty tracking follows the persistence outcome: refusals, verified rollbacks
+and verified content no-ops add no new dirty mark; changed or uncertain
+persistence remains dirty. This bookkeeping does not schedule a build.
+
+The complete metadata inventory is deliberately expensive and concurrent edits
+to other objects can prevent this candidate from committing. Metadata equality
+does not prove byte equality for another object's parts if an independent
+writer persisted those parts without advancing metadata. The optimistic token
+checks also do not establish atomic cross-process compare-and-swap semantics.
+Those are explicit limits, not new guarantees.
+
+For an authorized live test, capture the complete Events source/token and the
+other-part snapshots, preview a unique comment outside generated blocks, and
+prove the preview leaves snapshots and metadata unchanged. Test a stale token
+before a real save. After a successful isolated save, read again and restore
+only if the fresh token/content still match the test's own state. Restoration
+must use the same isolated path and the new token; it must not overwrite a
+concurrent edit. The final source must match the original exactly. Normal SDK
+revision/history advancement is recorded, never manually reset.
+
+## Live validation completed
+
+The fixed worker was loaded by the selected operational profile after its worker
+destination was corrected and the gateway was restarted. The profile was pinned
+to its expected KB path and editable version; no automatic update was enabled.
+`dryRun=true` reported verified SDK and broker isolation instead of
+`ObjectSaveIsolationUnverified`.
+
+Two content-changing writes and two restorations were executed through the
+normal asynchronous `genexus_edit` route with `requireObjectSave=true`:
+
+- An existing WWP master, part `Events`: temporary validation comment added and
+  removed. Both complete saves reported
+  `sdk_object_force_save_isolated`, `writeAttempted=true`,
+  `objectSaveInvoked=true`, `objectSaved=true`, `partPersisted=true`,
+  `otherPartsIntact=true`, `otherObjectMetadataIntact=true`, empty unexpected
+  part/object sets, and `reReadConfirmed=true`.
+- A new selector WebComponent, part `Events`: the same add/remove test. The
+  complete save passed the same checks and the final fresh read confirmed the
+  original source without the temporary marker.
+
+For both objects, the pre-commit SDK projection was limited to the known
+Rules/Conditions representation normalization; no unexpected persisted part or
+object was detected. The save scope set and restored `SkipApplyPattern`, ran
+the audited U16 callbacks, and verified both global and KB event brokers.
+
+The selector is classified by GeneXus as a WebComponent while its U16 SDK
+runtime class is the audited `Artech.Genexus.Common.Objects.WebPanel`; therefore
+the component's own complete Events save is covered by the same verified
+contract. Its WWP host was created by a targeted pattern operation. The parent
+master's PatternInstance received one narrow selector web-component entry under
+the existing table, and the generated WebForm projection was only
+inspected after the targeted pattern operation to verify that projection; no
+direct WebForm edit was made.
+
+No Build, Generate, Specify, Reorg, database operation, global pattern
+application, or direct generated WebForm edit was performed. The final KB
+source was reread after restoration; generated markers and the requested custom
+logic remain present.

--- a/docs/sdk-compatibility.md
+++ b/docs/sdk-compatibility.md
@@ -1,10 +1,12 @@
 # GeneXus SDK compatibility
 
-The Worker is compiled against the GeneXus 18 SDK installed on the build host. The SDK is proprietary and is intentionally **not** a NuGet dependency, checked into this repository, or copied into the npm/package artifacts.
+The Worker is compiled against the selected supported GeneXus major installed on the build host. The SDK is proprietary and is intentionally **not** a NuGet dependency, checked into this repository, or copied into the npm/package artifacts.
 
 ## Supported fixture
 
-`config/sdk-compatibility.json` is a public compatibility lock. It records the supported GeneXus product version and SHA-256 fingerprints for the assemblies the Worker references. It contains no SDK bytes or credentials. The current lock was produced from a self-hosted GeneXus 18 installation whose anchor product version is `18.0.10.184260`.
+`config/sdk-compatibility.json` records a reference GeneXus product version and SHA-256 fingerprints for selected assemblies the Worker references. The reference version selects the Worker major; minor, patch, build and hash differences within that major are diagnostics, not compatibility failures. The manifest contains no SDK bytes or credentials. The default reference was produced from a self-hosted GeneXus 18 installation whose anchor product version is `18.0.10.184260`.
+
+Both build and startup require the reference GeneXus major and all listed assemblies. The legacy `allowPatchVersionDrift` flag is no longer consulted: compatibility within the supported major does not require an opt-in. Fingerprint drift is reported even when ProductVersion is unchanged. These checks establish SDK compatibility, not validation of KB writes or save-event isolation.
 
 Provide the SDK through a self-hosted Windows build image or an installed developer workstation:
 
@@ -17,9 +19,10 @@ The build target runs `scripts/validate-gx-sdk.ps1` before resolving references.
 
 - `GXMCP_SDK_PATH_MISSING`
 - `GXMCP_SDK_VERSION_MISMATCH`
-- `GXMCP_SDK_FINGERPRINT_MISMATCH`
+- `GXMCP_SDK_ASSEMBLY_MISSING`
+- `GXMCP_SDK_FINGERPRINT_DRIFT` (informational; compatibility still succeeds)
 
-A mismatch is a failed build/startup, not a best-effort warning. To inspect the exact path and expected lock, run:
+A missing required assembly or different/unreadable major fails build/startup. A different major requires a Worker built and validated for that major; changing the manifest on an existing binary is not an upgrade path. To inspect the selected SDK and reference, run:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass `
@@ -30,4 +33,4 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 
 Do not publish proprietary DLLs, secrets, or a copied SDK fixture in CI. A CI runner without the self-hosted SDK should report the SDK build/live gate as unavailable; it must not claim that the Worker build passed.
 
-When intentionally upgrading the supported SDK, install the candidate on a controlled self-hosted image, run the validator, update the manifest hashes and version together, then run the focused tests and full verification gates. Treat the manifest as a reviewable compatibility decision, not as a license to redistribute the SDK.
+When upgrading within a supported major, run the validator, focused compatibility tests and the authorized live smoke. Refresh reference hashes when useful for diagnosis; exact hashes are not an acceptance gate. Adding a major also requires the explicit version catalog entry and a Worker built and live-tested for it. Package hashes still protect the integrity of our distributed binaries and rollback files; they are separate from SDK compatibility.

--- a/docs/sdk-compatibility.md
+++ b/docs/sdk-compatibility.md
@@ -8,6 +8,27 @@ The Worker is compiled against the GeneXus 18 SDK installed on the build host. T
 
 Provide the SDK through a self-hosted Windows build image or an installed developer workstation:
 
+Additional explicit locks are available for the inspected U11, U12 and U16
+installations in `config/sdk-compatibility-u11.json`,
+`config/sdk-compatibility-u12.json` and `config/sdk-compatibility-u16.json`.
+The original U10 lock remains the default. Select one lock for each build;
+the resulting Worker carries only that lock under `sdk-compatibility.json`.
+Both build and startup enforce its exact product version and all fingerprints.
+These hashes attest SDK identity, not validation of KB writes or save-event
+isolation. No proprietary SDK assemblies are added by these manifests.
+
+```powershell
+$env:GX_PATH = '<installed-upgrade-directory>'
+$env:GxMcpSdkManifest = (Resolve-Path '.\config\sdk-compatibility-u16.json').Path
+dotnet build src\GxMcp.Worker\GxMcp.Worker.csproj
+# build.ps1 also forwards GxMcpSdkManifest to its Release and Debug builds.
+```
+
+For a command-scoped choice, use `-p:GxMcpSdkManifest=<absolute-manifest-path>`.
+Clear the environment variable to return to the default U10 lock. Do not use
+`GxMcpSkipSdkValidation` to build upgrade packages. Switching upgrade builds
+replaces the output lock even when the selected source manifest is older.
+
 ```powershell
 $env:GX_PATH = 'C:\Program Files (x86)\GeneXus\GeneXus18'
 dotnet build src\GxMcp.Worker\GxMcp.Worker.csproj
@@ -31,3 +52,5 @@ powershell -NoProfile -ExecutionPolicy Bypass `
 Do not publish proprietary DLLs, secrets, or a copied SDK fixture in CI. A CI runner without the self-hosted SDK should report the SDK build/live gate as unavailable; it must not claim that the Worker build passed.
 
 When intentionally upgrading the supported SDK, install the candidate on a controlled self-hosted image, run the validator, update the manifest hashes and version together, then run the focused tests and full verification gates. Treat the manifest as a reviewable compatibility decision, not as a license to redistribute the SDK.
+
+Worker test SDK dependencies are refreshed when switching `GX_PATH`. The copy target excludes resolved project/NuGet dependencies (for example Newtonsoft.Json) before copying SDK DLLs, so changing upgrades replaces stale SDK assemblies without replacing application dependencies. For a full SDK matrix, use a separate output directory under the worktree for each upgrade, and compare the output DLL hashes with the selected lock. Keeping outputs inside the worktree also supports tests that locate source files by walking parent directories.

--- a/scripts/tests/sdk-validation-contract.tests.ps1
+++ b/scripts/tests/sdk-validation-contract.tests.ps1
@@ -40,9 +40,46 @@ try {
     $status = Get-Content -LiteralPath $statusPath -Raw | ConvertFrom-Json
     if ($status.state -ne 'fail') { throw "Expected fail state, got $($status.state)." }
     if (@(Get-ChildItem -LiteralPath $outputRoot -Filter 'run-*' -Directory).Count -ne 0) { throw 'Run directory was not cleaned after failure.' }
+
+    # A copy of the test host's PE exercises the real validator without any GeneXus DLL or KB.
+    $anchor = Join-Path $sdk 'Artech.Architecture.Common.dll'
+    Copy-Item -LiteralPath ([System.Management.Automation.PSObject].Assembly.Location) -Destination $anchor
+    $fixtureVersion = [Diagnostics.FileVersionInfo]::GetVersionInfo($anchor).ProductVersion
+    $fixtureMajor = [int]($fixtureVersion -split '\.')[0]
+    $compatManifest = Join-Path $outputRoot 'sdk-compatibility.json'
+    $spec = @{
+        supportedVersion = $fixtureVersion
+        anchor = 'Artech.Architecture.Common.dll'
+        assemblies = @(@{ path = 'Artech.Architecture.Common.dll'; sha256 = (Get-FileHash -LiteralPath $anchor -Algorithm SHA256).Hash })
+    }
+    $validator = Join-Path $PSScriptRoot '../validate-gx-sdk.ps1'
+    function Assert-SdkValidation([int]$exitCode, [string]$diagnostic) {
+        $spec | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $compatManifest -Encoding utf8
+        $output = & powershell.exe -NoProfile -File $validator -GxPath $sdk -Manifest $compatManifest 2>&1 | Out-String
+        if ($LASTEXITCODE -ne $exitCode -or -not $output.Contains($diagnostic)) {
+            throw "SDK validator expected exit=$exitCode and '$diagnostic', got exit=$LASTEXITCODE`: $output"
+        }
+    }
+    Assert-SdkValidation 0 'GXMCP_SDK_COMPATIBLE'
+    $spec.assemblies[0].sha256 = '0' * 64
+    Assert-SdkValidation 0 'GXMCP_SDK_FINGERPRINT_DRIFT'
+    $spec.supportedVersion = "$fixtureMajor.0.10.184260"
+    Assert-SdkValidation 0 'compatible major; patch/build drift'
+    $spec.allowPatchVersionDrift = $false
+    $spec.supportedVersion = "$fixtureMajor.1.0.0"
+    Assert-SdkValidation 0 'GXMCP_SDK_COMPATIBLE'
+    $spec.supportedVersion = "$($fixtureMajor + 1).0.16.189550"
+    Assert-SdkValidation 1 'GXMCP_SDK_VERSION_MISMATCH'
+    $spec.supportedVersion = 'invalid'
+    Assert-SdkValidation 1 'GXMCP_SDK_VERSION_MISMATCH'
+    $spec.supportedVersion = $fixtureVersion
+    $spec.assemblies[0].path = 'missing-required.dll'
+    Assert-SdkValidation 1 'GXMCP_SDK_ASSEMBLY_MISSING'
+    $spec.assemblies = @()
+    Assert-SdkValidation 1 'GXMCP_SDK_MANIFEST_INVALID'
 }
 finally {
     $env:GXMCP_SDK_CI_LICENSE_ACK = $oldAck
     Remove-Item -LiteralPath $outputRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
-Write-Host 'PASS: SDK lane syntax, explicit pass/skip/fail states, preconditions, status artifact, and cleanup contract.'
+Write-Host 'PASS: SDK lane syntax, pass/skip/fail states, cleanup, and 8 no-KB build-validator major/fingerprint/required-assembly cases.'

--- a/scripts/validate-gx-sdk.ps1
+++ b/scripts/validate-gx-sdk.ps1
@@ -23,12 +23,17 @@ if (-not (Test-Path -LiteralPath $anchor -PathType Leaf)) {
     Fail "GXMCP_SDK_ANCHOR_MISSING path=$($spec.anchor)"
 }
 $actualVersion = [Diagnostics.FileVersionInfo]::GetVersionInfo($anchor).ProductVersion
-$expectedParts = $spec.supportedVersion.Split('.')
-$actualParts = $actualVersion.Split('.')
-$sameMajorMinor = $expectedParts.Count -ge 2 -and $actualParts.Count -ge 2 -and $expectedParts[0] -eq $actualParts[0] -and $expectedParts[1] -eq $actualParts[1]
+$expectedMajor = 0
+$actualMajor = 0
+$sameMajor = [int]::TryParse(([string]$spec.supportedVersion -split '\.')[0], [ref]$expectedMajor) -and
+    [int]::TryParse(([string]$actualVersion -split '\.')[0], [ref]$actualMajor) -and
+    $expectedMajor -gt 0 -and $expectedMajor -eq $actualMajor
 $exactVersion = $actualVersion -eq $spec.supportedVersion
-if (-not $exactVersion -and -not ($spec.allowPatchVersionDrift -and $sameMajorMinor)) {
+if (-not $sameMajor) {
     Fail "GXMCP_SDK_VERSION_MISMATCH expectedVersion=$($spec.supportedVersion) actualVersion=$actualVersion"
+}
+if (-not $spec.assemblies -or $spec.assemblies.Count -eq 0) {
+    Fail "GXMCP_SDK_MANIFEST_INVALID manifest=$Manifest error=assemblies"
 }
 foreach ($assembly in $spec.assemblies) {
     $file = Join-Path $GxPath $assembly.path
@@ -41,10 +46,10 @@ foreach ($assembly in $spec.assemblies) {
         $actualHash = ([BitConverter]::ToString($sha.ComputeHash($bytes))).Replace('-', '').ToLowerInvariant()
     }
     finally { $sha.Dispose() }
-    if ($exactVersion -and $actualHash -ne $assembly.sha256.ToLowerInvariant()) {
-        Fail "GXMCP_SDK_FINGERPRINT_MISMATCH path=$($assembly.path) expectedSha256=$($assembly.sha256) actualSha256=$actualHash"
+    if ($actualHash -ne $assembly.sha256) {
+        Write-Output "GXMCP_SDK_FINGERPRINT_DRIFT path=$($assembly.path) expectedSha256=$($assembly.sha256) actualSha256=$actualHash"
     }
 }
-if ($exactVersion) { $versionDiagnostic = $spec.supportedVersion } else { $versionDiagnostic = "$($spec.supportedVersion) actualVersion=$actualVersion (compatible patch drift)" }
+if ($exactVersion) { $versionDiagnostic = $spec.supportedVersion } else { $versionDiagnostic = "$($spec.supportedVersion) actualVersion=$actualVersion (compatible major; patch/build drift)" }
 Write-Output "GXMCP_SDK_COMPATIBLE version=$versionDiagnostic assemblies=$($spec.assemblies.Count)"
 exit 0

--- a/src/GxMcp.Gateway.Tests/LegacyHubProfileCompatibilityTests.cs
+++ b/src/GxMcp.Gateway.Tests/LegacyHubProfileCompatibilityTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxMcp.Gateway.Tests
+{
+    [Collection("Gateway route state")]
+    public sealed class LegacyHubProfileCompatibilityTests
+    {
+        [Theory]
+        [InlineData("legacy", true)]
+        [InlineData("strict", false)]
+        public async Task DedicatedHttpProfileWithoutSelection_UsesOnlyExplicitLegacyFallback(string policy, bool reachesHandler)
+        {
+            string directory = Path.Combine(Path.GetTempPath(), "gxmcp-hub-contract-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            // This is a parser sentinel, not a KB. No Worker executable is available.
+            File.WriteAllText(Path.Combine(directory, "Example.gxw"), "");
+            string configPath = Path.Combine(directory, "config.json");
+            var document = new JObject
+            {
+                ["GeneXus"] = new JObject { ["InstallationPath"] = "not-installed", ["WorkerExecutable"] = "not-a-worker.exe" },
+                ["Server"] = new JObject { ["HttpPort"] = 54321, ["McpStdio"] = false, ["MaxOpenKbs"] = 1 },
+                ["Environment"] = new JObject { ["KBPath"] = directory, ["ResolutionPolicy"] = policy }
+            };
+            File.WriteAllText(configPath, document.ToString());
+            var parse = typeof(Configuration).GetMethod("ParseConfig", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var config = (Configuration)parse.Invoke(null, new object[] { configPath })!;
+            try
+            {
+                using var scope = Program.ConfigureRouteStateForTest(config, configPath);
+                Assert.Null(config.ConfigSchemaVersion);
+                Assert.Null(config.GatewayMode);
+                Assert.Equal(54321, config.Server!.HttpPort);
+                Assert.False(config.Server.McpStdio);
+                Assert.Single(config.Environment!.KBs);
+                // Match Hub: classic MCP HTTP session, JSON + SSE Accept, no explicit
+                // KB argument or select/lease. An invalid macro name stops before I/O.
+                var request = new JObject
+                {
+                    ["jsonrpc"] = "2.0", ["id"] = 1, ["method"] = "tools/call",
+                    ["params"] = new JObject
+                    {
+                        ["name"] = "genexus_recipe",
+                        ["arguments"] = new JObject { ["action"] = "crystallize", ["macroName"] = "invalid/name", ["steps"] = new JArray(new JObject()) }
+                    }
+                };
+                string session = Program.CreateHttpSessionForTest();
+                var context = new DefaultHttpContext();
+                context.Request.ContentType = "application/json";
+                context.Request.Headers["Accept"] = "application/json, text/event-stream";
+                context.Request.Headers["MCP-Protocol-Version"] = "2025-11-25";
+                context.Request.Headers["MCP-Session-Id"] = session;
+                context.RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider();
+                context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(request.ToString()));
+                context.Response.Body = new MemoryStream();
+                var result = await Program.HandleJsonRpcHttpRequest(context.Request);
+                await result.ExecuteAsync(context);
+                context.Response.Body.Position = 0;
+                var response = JObject.Parse(await new StreamReader(context.Response.Body).ReadToEndAsync());
+                var payload = JObject.Parse(response["result"]!["content"]![0]!["text"]!.ToString());
+                if (reachesHandler)
+                    Assert.Contains("macroName must match", payload.ToString());
+                else
+                    Assert.Contains("KB_CONTEXT_REQUIRED", payload.ToString());
+                Assert.Empty(Program.GetWorkerPool()!.ListOpen());
+                Assert.Equal(document.ToString(), File.ReadAllText(configPath));
+            }
+            finally
+            {
+                File.Delete(configPath);
+                File.Delete(Path.Combine(directory, "Example.gxw"));
+                Directory.Delete(directory);
+            }
+        }
+    }
+}

--- a/src/GxMcp.Gateway.Tests/RouterContractCoverageTests.cs
+++ b/src/GxMcp.Gateway.Tests/RouterContractCoverageTests.cs
@@ -10,6 +10,23 @@ namespace GxMcp.Gateway.Tests
     public class RouterContractCoverageTests
     {
         [Theory]
+        [InlineData("types_list", "list")]
+        [InlineData("types_describe", "describe")]
+        [InlineData("types_validate", "validate_value")]
+        public void Db_types_normalizes_worker_action_without_mutating_caller(string action, string workerAction)
+        {
+            var args = new JObject { ["action"] = action, ["name"] = "ExampleDomain", ["type"] = "domain" };
+            var routed = JObject.FromObject(new OperationsRouter().ConvertToolCall("genexus_db", args)!);
+
+            Assert.Equal("types", (string?)routed["module"]);
+            Assert.Equal(workerAction, (string?)routed["action"]);
+            Assert.Equal(workerAction, (string?)routed["params"]?["action"]);
+            Assert.Equal("ExampleDomain", (string?)routed["params"]?["name"]);
+            Assert.Equal("domain", (string?)routed["params"]?["type"]);
+            Assert.Equal(action, (string?)args["action"]);
+        }
+
+        [Theory]
         [InlineData("genexus_delete_object", "{}", "Object", "Delete")]
         [InlineData("genexus_worker_reload", "{}", "Object", "WorkerReload")]
         [InlineData("genexus_validate_payload", "{}", "Write", "ValidatePayload")]

--- a/src/GxMcp.Gateway/Routers/DatabaseRouter.cs
+++ b/src/GxMcp.Gateway/Routers/DatabaseRouter.cs
@@ -95,12 +95,14 @@ namespace GxMcp.Gateway.Routers
                         "types_describe" => "describe",
                         _ => "validate_value"
                     };
+                    var workerArgs = args == null ? new JObject() : (JObject)args.DeepClone();
+                    workerArgs["action"] = inner;
                     return new
                     {
                         module = "types",
                         action = inner,
                         target = args?["name"]?.ToString() ?? args?["type"]?.ToString() ?? target,
-                        @params = args
+                        @params = workerArgs
                     };
                 }
 

--- a/src/GxMcp.Worker.Tests/DomainPropertyApplierTests.cs
+++ b/src/GxMcp.Worker.Tests/DomainPropertyApplierTests.cs
@@ -18,6 +18,18 @@ namespace GxMcp.Worker.Tests
             public object DomainBasedOn { get; set; }
         }
 
+        public class FakeEnumValue
+        {
+            public string Name { get; set; }
+            public string Value { get; set; }
+            public string Description { get; set; }
+        }
+
+        public class FakeEnumerableDomain
+        {
+            public List<FakeEnumValue> EnumValues { get; } = new List<FakeEnumValue>();
+        }
+
         [Fact]
         public void ApplyPrimitive_SetsTypeLengthDecimalsSigned()
         {
@@ -129,6 +141,25 @@ namespace GxMcp.Worker.Tests
         {
             var d = new FakeDomain();
             Assert.Equal(0, DomainPropertyApplier.ApplyEnumValues(d, new List<DomainEnumValueSpec>()));
+        }
+
+        [Fact]
+        public void ReadEnumValues_AcceptsDirectlyEnumerableSdkShape()
+        {
+            var d = new FakeEnumerableDomain();
+            d.EnumValues.Add(new FakeEnumValue
+            {
+                Name = "Queued",
+                Value = "1",
+                Description = "Waiting"
+            });
+
+            var values = DomainPropertyApplier.ReadEnumValues(d);
+
+            var value = Assert.Single(values);
+            Assert.Equal("Queued", (string)value["name"]);
+            Assert.Equal("1", (string)value["value"]);
+            Assert.Equal("Waiting", (string)value["description"]);
         }
     }
 }

--- a/src/GxMcp.Worker.Tests/EventsSaveIsolationTests.cs
+++ b/src/GxMcp.Worker.Tests/EventsSaveIsolationTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Reflection;
+using Artech.Architecture.Common.Objects;
+using GxMcp.Worker.Helpers;
+using GxMcp.Worker.Services;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxMcp.Worker.Tests
+{
+    public sealed class EventsSaveIsolationTests
+    {
+        [Theory]
+        [InlineData("{}", false)]
+        [InlineData("{writeAttempted:false}", false)]
+        [InlineData("{writeAttempted:true, rollbackVerified:true, persistenceUncertain:true}", false)]
+        [InlineData("{writeAttempted:true, persistenceUncertain:true}", true)]
+        [InlineData("{writeAttempted:true, rollbackError:'failed'}", true)]
+        [InlineData("{writeAttempted:true, objectSaved:true, sourceChanged:true, partPersisted:true}", true)]
+        [InlineData("{writeAttempted:true, verificationCompleted:true, objectSaved:true, partPersisted:true, otherPartsIntact:true, otherObjectMetadataIntact:true, sourceChanged:false}", false)]
+        [InlineData("{writeAttempted:true, verificationCompleted:true, objectSaved:true, partPersisted:true, otherPartsIntact:true, otherObjectMetadataIntact:true, sourceChanged:false, persistenceUncertain:true}", true)]
+        [InlineData("{writeAttempted:true, verificationCompleted:true, objectSaved:true, partPersisted:true, otherPartsIntact:false, otherObjectMetadataIntact:true, sourceChanged:false}", true)]
+        public void DirtyTracking_UsesPersistenceOutcome(string json, bool expected)
+            => Assert.Equal(expected, WriteService.ShouldMarkIsolatedEventsDirty(JObject.Parse(json)));
+
+        [Fact]
+        public void TransactionOutcome_InvalidatesAllReadLayersAndIdentityAliasesWithoutSdk()
+        {
+            string name = "IsolationCache_" + Guid.NewGuid().ToString("N");
+            string guid = Guid.NewGuid().ToString();
+            var reader = new ObjectReader(null);
+            var nameRequest = new ObjectReadRequest { Target = name, PartName = "Events", ClientFormat = "mcp" };
+            var guidRequest = new ObjectReadRequest { Target = guid, PartName = "Events", ClientFormat = "mcp" };
+            var readerCache = PopulateCache(typeof(ObjectReader), "_cache", ObjectReader.BuildCacheKey(nameRequest));
+            PopulateCache(typeof(ObjectReader), "_cache", ObjectReader.BuildCacheKey(guidRequest));
+            var patchCache = PopulateCache(typeof(PatchService), "_sourceCache", "WebPanel|" + name + "|Events");
+            PopulateCache(typeof(PatchService), "_sourceCache", "WebPanel|" + guid + "|Events");
+            var sourceCache = PopulateCache(typeof(ObjectService), "_readCache", guid.Replace("-", "") + "|events|raw");
+            PopulateCache(typeof(ObjectService), "_readCache", guid.Replace("-", "") + "|full|all");
+            Assert.True(reader.TryGetCached(name, "Events", null, null, "mcp", out _));
+            Assert.True(reader.TryGetCached(guid, "Events", null, null, "mcp", out _));
+
+            WriteService.InvalidateIsolatedEventsReadCaches();
+
+            Assert.False(reader.TryGetCached(name, "Events", null, null, "mcp", out _));
+            Assert.False(reader.TryGetCached(guid, "Events", null, null, "mcp", out _));
+            Assert.Empty(readerCache);
+            Assert.Empty(patchCache);
+            Assert.Empty(sourceCache);
+        }
+
+        private static IDictionary PopulateCache(Type owner, string field, string key)
+        {
+            var cache = (IDictionary)owner.GetField(field, BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
+            Type entryType = cache.GetType().GetGenericArguments()[1];
+            object entry = Activator.CreateInstance(entryType, nonPublic: true);
+            foreach (var property in entryType.GetProperties())
+            {
+                if (property.PropertyType == typeof(string)) property.SetValue(entry, "stale persisted source");
+                if (property.PropertyType == typeof(DateTime)) property.SetValue(entry, DateTime.UtcNow);
+            }
+            cache[key] = entry;
+            return cache;
+        }
+
+        private class SyntheticBase
+        {
+            private readonly Action _onSave;
+            public int Calls;
+            public SyntheticBase() { _onSave = () => Calls++; }
+        }
+        private sealed class SyntheticChild : SyntheticBase { }
+
+        [Fact]
+        public void UnknownDirectCallbackInBaseClass_IsRejectedWithoutCallingIt()
+        {
+            var instance = new SyntheticChild();
+            Assert.Throws<InvalidOperationException>(() => EventsSaveIsolation.InspectDirectCallbacks(instance, new JArray()));
+            Assert.Equal(0, instance.Calls);
+        }
+
+        [Fact]
+        public void MissingObject_IsRejectedBeforeSdkAccess()
+            => Assert.Throws<InvalidOperationException>(() => EventsSaveIsolation.Preflight(null));
+
+        [Fact]
+        public void PatternVirtualPart_IsTheOnlyCertifiedVirtualPart()
+        {
+            Assert.True(EventsSaveIsolation.IsAllowedPartTypeName(
+                "Artech.Packages.Patterns.Objects.PatternVirtualPart"));
+            Assert.False(EventsSaveIsolation.IsAllowedPartType(typeof(KBObjectPart)));
+        }
+
+        [Fact]
+        public void SourceComparison_AllowsSdkEolNormalizationOnly()
+        {
+            Assert.True(EventsSaveIsolation.SourceEquivalent("a\r\nb\r\n", "a\nb\n"));
+            Assert.False(EventsSaveIsolation.SourceEquivalent("a\nb", "a\nc"));
+        }
+
+        [Fact]
+        public void MetadataAudit_DetectsOtherObjectsChangedAddedRemoved_ExcludesOnlyTarget()
+        {
+            var target = Guid.NewGuid(); var changed = Guid.NewGuid();
+            var removed = Guid.NewGuid(); var added = Guid.NewGuid(); var unchanged = Guid.NewGuid();
+            var before = new Dictionary<Guid, string> { [target] = "1", [changed] = "1", [removed] = "1", [unchanged] = "1" };
+            var after = new Dictionary<Guid, string> { [target] = "2", [changed] = "2", [added] = "1", [unchanged] = "1" };
+            var result = EventsSaveIsolation.ChangedOthers(before, after, target);
+            Assert.Equal(3, result.Count);
+            Assert.Contains(changed.ToString(), result.ToObject<string[]>());
+            Assert.Contains(removed.ToString(), result.ToObject<string[]>());
+            Assert.Contains(added.ToString(), result.ToObject<string[]>());
+        }
+    }
+}

--- a/src/GxMcp.Worker.Tests/EventsSaveIsolationTests.cs
+++ b/src/GxMcp.Worker.Tests/EventsSaveIsolationTests.cs
@@ -96,9 +96,7 @@ namespace GxMcp.Worker.Tests
         [Fact]
         public void SourceComparison_AllowsSdkEolNormalizationOnly()
         {
-            Assert.True(EventsSaveIsolation.SourceEquivalent("a
-\nb
-\n", "a\nb\n"));
+            Assert.True(EventsSaveIsolation.SourceEquivalent("a" + Environment.NewLine + "b" + Environment.NewLine, "a" + (char)10 + "b" + (char)10));
             Assert.False(EventsSaveIsolation.SourceEquivalent("a\nb", "a\nc"));
         }
 

--- a/src/GxMcp.Worker.Tests/GxMcp.Worker.Tests.csproj
+++ b/src/GxMcp.Worker.Tests/GxMcp.Worker.Tests.csproj
@@ -45,11 +45,12 @@
   <Target Name="CopyGeneXusSdkDependencies" AfterTargets="Build" Condition="Exists('$(GX_PATH)\Artech.Architecture.Common.dll')">
     <ItemGroup>
       <GeneXusSdkDependency Include="$(GX_PATH)\*.dll;$(GX_PATH)\Packages\*.dll" />
+      <!-- Preserve NuGet/project dependencies; refresh SDK files when GX_PATH changes. -->
+      <GeneXusSdkDependency Remove="@(ReferenceCopyLocalPaths)" MatchOnMetadata="Filename" MatchOnMetadataOptions="CaseInsensitive" />
     </ItemGroup>
     <Copy
       SourceFiles="@(GeneXusSdkDependency)"
       DestinationFolder="$(TargetDir)"
-      SkipUnchangedFiles="true"
-      Condition="!Exists('$(TargetDir)%(GeneXusSdkDependency.Filename)%(GeneXusSdkDependency.Extension)')" />
+      SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/src/GxMcp.Worker.Tests/IndexShardingTests.cs
+++ b/src/GxMcp.Worker.Tests/IndexShardingTests.cs
@@ -84,6 +84,67 @@ namespace GxMcp.Worker.Tests
         }
 
         [Fact]
+        public void VersionedSnapshot_FailedPublicationRetriesEveryDirtyShard()
+        {
+            string kbPath = UniqueKbPath();
+            var cache = new IndexCacheService();
+            cache.Initialize(kbPath, proactiveLoad: false);
+            try
+            {
+                var entry = Entry("Procedure", "RetryProbe");
+                entry.Description = "before";
+                cache.ReplaceAll(new[] { entry });
+                Assert.True(cache.FlushNow(), IndexCacheService.LastFlushErrorMessage ?? "no error");
+                string originalPointer = File.ReadAllText(cache.SnapshotPointerPathForTest);
+                long originalGeneration = cache.FlushedGeneration;
+
+                cache.AddOrUpdateBatch(new[] {
+                    new SearchIndex.IndexEntry {
+                        Name = entry.Name, Type = entry.Type, Guid = entry.Guid, Description = "after"
+                    }
+                });
+                using (File.Open(cache.SnapshotPointerPathForTest, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    Assert.False(cache.FlushNow(100));
+                    Assert.False(cache.IsFullyFlushed);
+                    Assert.Equal(originalGeneration, cache.FlushedGeneration);
+                    Assert.Equal(originalPointer, File.ReadAllText(cache.SnapshotPointerPathForTest));
+                }
+
+                Assert.True(cache.FlushNow(), IndexCacheService.LastFlushErrorMessage ?? "no error");
+                Assert.True(cache.IsFullyFlushed);
+                var reloaded = new IndexCacheService();
+                reloaded.Initialize(kbPath, proactiveLoad: false);
+                Assert.Equal("after", reloaded.GetIndex().Objects["Procedure:RetryProbe"].Description);
+            }
+            finally { cache.DeleteOnDiskSnapshot(); }
+        }
+
+        [Fact]
+        public void VersionedSnapshot_NewBodyRequiresItsOwnEnrichmentCertificate()
+        {
+            var cache = new IndexCacheService();
+            cache.Initialize(UniqueKbPath(), proactiveLoad: false);
+            try
+            {
+                cache.ReplaceAll(new[] { Entry("Procedure", "CertifiedBody") });
+                Assert.True(cache.FlushNow(), IndexCacheService.LastFlushErrorMessage ?? "no error");
+                cache.ObserveLastUpdate(DateTime.UtcNow);
+                cache.WriteMetaSidecar(1);
+                Assert.True(cache.ValidateOnDiskCache().CanDelta);
+
+                cache.AddOrUpdateBatch(new[] { Entry("Procedure", "AwaitingEnrichment") });
+                Assert.True(cache.FlushNow(), IndexCacheService.LastFlushErrorMessage ?? "no error");
+                var validation = cache.ValidateOnDiskCache();
+                Assert.True(validation.BodyPresent);
+                Assert.False(validation.MetaPresent);
+                Assert.False(validation.CanDelta);
+                Assert.False(validation.CanDeltaAcrossDll);
+            }
+            finally { cache.DeleteOnDiskSnapshot(); }
+        }
+
+        [Fact]
         public void VersionedSnapshot_IgnoresAbandonedRebuildSlotAndLoadsCertifiedGeneration()
         {
             string kbPath = UniqueKbPath();

--- a/src/GxMcp.Worker.Tests/PatternXmlEditPlanTests.cs
+++ b/src/GxMcp.Worker.Tests/PatternXmlEditPlanTests.cs
@@ -74,6 +74,33 @@ namespace GxMcp.Worker.Tests
         }
 
         [Fact]
+        public void AllowsOnlyAWebComponentInsertionIntoAnExistingTable()
+        {
+            const string current = "<instance><table name='Header' childrenOrderedList='2;18;Admin'><userAction name='Admin' gxobject='old'/></table></instance>";
+            const string requested = "<instance><table name='Header' childrenOrderedList='2;18;Admin'><userAction name='Admin' gxobject='old'/><webComponent name='SelectorComponent' gxobject='type-SelectorWebComponent'/></table></instance>";
+
+            var plan = PatternXmlEditPlan.Create(current, requested);
+
+            Assert.Null(plan.ErrorCode);
+            Assert.Single(plan.Changes);
+            Assert.Equal("Insert", (string)plan.Changes[0]["operation"]);
+            Assert.Contains("webComponent", (string)plan.Changes[0]["path"]);
+            Assert.Equal(requested, plan.Xml);
+        }
+
+        [Fact]
+        public void RejectsAWebComponentWithUnsupportedStructureOrMetadata()
+        {
+            const string current = "<instance><table name='Header'><userAction name='Admin'/></table></instance>";
+            const string unsupported = "<instance><table name='Header'><userAction name='Admin'/><webComponent name='SelectorComponent' gxobject='type-SelectorWebComponent' childrenOrderedList='x'/></table></instance>";
+
+            var plan = PatternXmlEditPlan.Create(current, unsupported);
+
+            Assert.Equal("PatternStructureChangeUnsupported", plan.ErrorCode);
+            Assert.Empty(plan.Changes);
+        }
+
+        [Fact]
         public void NamespacesAndTextRemainUntouchedForPropertyEdits()
         {
             const string xml = "<p:instance xmlns:p='urn:pattern'><p:table name='Main' p:class='Old'>keep &amp; preserve<![CDATA[ literal ]]><!-- note --></p:table></p:instance>";

--- a/src/GxMcp.Worker.Tests/SdkCompatibilityValidatorTests.cs
+++ b/src/GxMcp.Worker.Tests/SdkCompatibilityValidatorTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
-using System.Text;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -9,6 +8,24 @@ namespace GxMcp.Worker.Tests
 {
     public class SdkCompatibilityValidatorTests
     {
+        [Theory]
+        [InlineData("18.0.10.184260")]
+        [InlineData("18.0.11.185416+build11")]
+        [InlineData("18.0.12.186073+build12")]
+        [InlineData("18.0.16.189550+build16")]
+        public void SelectedManifest_AllowsSameMajorDriftAndReportsChangedFingerprints(string version)
+        {
+            using (var fixture = new SdkFixture(version, "selected-sdk"))
+            {
+                Assert.True(SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version).IsCompatible);
+                Assert.True(SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version + "-different").IsCompatible);
+                File.WriteAllText(Path.Combine(fixture.Root, "Artech.Architecture.Common.dll"), "different-sdk-bytes");
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version);
+                Assert.True(result.IsCompatible);
+                Assert.Contains("GXMCP_SDK_FINGERPRINT_DRIFT", result.Diagnostic);
+            }
+        }
+
         [Fact]
         public void Validate_ReturnsCompatibleForMatchingVersionAndFingerprint()
         {
@@ -22,15 +39,16 @@ namespace GxMcp.Worker.Tests
         }
 
         [Fact]
-        public void Validate_RejectsFingerprintMismatchWithStableDiagnostic()
+        public void Validate_ReportsFingerprintDriftWithTheSameProductVersionWithoutBlocking()
         {
             using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
             {
                 File.WriteAllText(Path.Combine(fixture.Root, "Artech.Architecture.Common.dll"), "tampered");
                 var result = GxMcp.Worker.SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.10.184260");
 
-                Assert.False(result.IsCompatible);
-                Assert.Equal("GXMCP_SDK_FINGERPRINT_MISMATCH", result.Code);
+                Assert.True(result.IsCompatible);
+                Assert.Equal("GXMCP_SDK_COMPATIBLE", result.Code);
+                Assert.Contains("GXMCP_SDK_FINGERPRINT_DRIFT", result.Diagnostic);
                 Assert.Contains("expectedSha256=", result.Diagnostic);
                 Assert.Contains("actualSha256=", result.Diagnostic);
             }
@@ -48,43 +66,84 @@ namespace GxMcp.Worker.Tests
             Assert.Equal("GXMCP_SDK_PATH_MISSING path=<missing>", result.Diagnostic);
         }
 
-        [Fact]
-        public void Validate_ReportsVersionMismatchBeforeAssemblyDetails()
-        {
-            using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
-            {
-                File.WriteAllText(fixture.Manifest, File.ReadAllText(fixture.Manifest).Replace("18.0.10.184260", "18.0.9.0"));
-                var result = GxMcp.Worker.SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.10.184260");
-
-                Assert.False(result.IsCompatible);
-                Assert.Equal("GXMCP_SDK_VERSION_MISMATCH", result.Code);
-                Assert.Contains("expectedVersion=18.0.9.0", result.Diagnostic);
-                Assert.Contains("actualVersion=18.0.10.184260", result.Diagnostic);
-            }
-        }
-
-        [Fact]
-        public void Validate_AllowsDeclaredPatchDriftWithinSameMajorMinor()
+        [Theory]
+        [InlineData("17.0.10.184260")]
+        [InlineData("19.0.10.184260")]
+        [InlineData("invalid")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Validate_RejectsDifferentOrUnreadableMajorBeforeAssemblyDetails(string actualVersion)
         {
             using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
             {
                 var json = JObject.Parse(File.ReadAllText(fixture.Manifest));
-                json["allowPatchVersionDrift"] = true;
+                json["assemblies"] = new JArray();
                 File.WriteAllText(fixture.Manifest, json.ToString());
-                var result = GxMcp.Worker.SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.14.187794");
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => actualVersion);
+
+                Assert.False(result.IsCompatible);
+                Assert.Equal("GXMCP_SDK_VERSION_MISMATCH", result.Code);
+                Assert.Contains("expectedVersion=18.0.10.184260", result.Diagnostic);
+                Assert.Contains("actualVersion=" + actualVersion, result.Diagnostic);
+            }
+        }
+
+        [Theory]
+        [InlineData("18.0.14.187794", true)]
+        [InlineData("18.0.16.189550+build16", false)]
+        [InlineData("18.1.0.0", false)]
+        public void Validate_AllowsSameMajorDriftRegardlessOfLegacyOptIn(string actualVersion, bool legacyOptIn)
+        {
+            using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
+            {
+                var json = JObject.Parse(File.ReadAllText(fixture.Manifest));
+                json["allowPatchVersionDrift"] = legacyOptIn;
+                File.WriteAllText(fixture.Manifest, json.ToString());
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => actualVersion);
                 Assert.True(result.IsCompatible);
-                Assert.Contains("compatible patch drift", result.Diagnostic);
+                Assert.Contains("compatible major; patch/build drift", result.Diagnostic);
             }
         }
 
         [Fact]
-        public void Validate_RejectsPatchDriftWhenManifestDoesNotOptIn()
+        public void Validate_AllowsPatchDriftWithoutLegacyOptIn()
         {
             using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
             {
                 var result = GxMcp.Worker.SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.14.187794");
+                Assert.True(result.IsCompatible);
+                Assert.Equal("GXMCP_SDK_COMPATIBLE", result.Code);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Validate_RejectsMissingRequiredAssemblyEvenWithCompatibleVersion(bool patchDrift)
+        {
+            using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
+            {
+                var json = JObject.Parse(File.ReadAllText(fixture.Manifest));
+                json["assemblies"][0]["path"] = "missing-required.dll";
+                File.WriteAllText(fixture.Manifest, json.ToString());
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest,
+                    _ => patchDrift ? "18.0.16.189550" : "18.0.10.184260");
                 Assert.False(result.IsCompatible);
-                Assert.Equal("GXMCP_SDK_VERSION_MISMATCH", result.Code);
+                Assert.Equal("GXMCP_SDK_ASSEMBLY_MISSING", result.Code);
+            }
+        }
+
+        [Fact]
+        public void Validate_RejectsManifestWithoutRequiredAssemblies()
+        {
+            using (var fixture = new SdkFixture("18.0.10.184260", "supported"))
+            {
+                var json = JObject.Parse(File.ReadAllText(fixture.Manifest));
+                json["assemblies"] = new JArray();
+                File.WriteAllText(fixture.Manifest, json.ToString());
+                var result = SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => "18.0.16.189550");
+                Assert.False(result.IsCompatible);
+                Assert.Equal("GXMCP_SDK_MANIFEST_INVALID", result.Code);
             }
         }
 

--- a/src/GxMcp.Worker.Tests/SdkCompatibilityValidatorTests.cs
+++ b/src/GxMcp.Worker.Tests/SdkCompatibilityValidatorTests.cs
@@ -9,6 +9,24 @@ namespace GxMcp.Worker.Tests
 {
     public class SdkCompatibilityValidatorTests
     {
+        [Theory]
+        [InlineData("18.0.10.184260")]
+        [InlineData("18.0.11.185416+build11")]
+        [InlineData("18.0.12.186073+build12")]
+        [InlineData("18.0.16.189550+build16")]
+        public void SelectedLock_AcceptsOnlyMatchingUpgradeAndFingerprint(string version)
+        {
+            using (var fixture = new SdkFixture(version, "selected-sdk"))
+            {
+                Assert.True(SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version).IsCompatible);
+                Assert.Equal("GXMCP_SDK_VERSION_MISMATCH",
+                    SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version + "-different").Code);
+                File.WriteAllText(Path.Combine(fixture.Root, "Artech.Architecture.Common.dll"), "different-sdk-bytes");
+                Assert.Equal("GXMCP_SDK_FINGERPRINT_MISMATCH",
+                    SdkCompatibilityValidator.Validate(fixture.Root, fixture.Manifest, _ => version).Code);
+            }
+        }
+
         [Fact]
         public void Validate_ReturnsCompatibleForMatchingVersionAndFingerprint()
         {

--- a/src/GxMcp.Worker.Tests/SdkEventSuppressionAsyncTests.cs
+++ b/src/GxMcp.Worker.Tests/SdkEventSuppressionAsyncTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Threading;
+using Artech.Architecture.Common.Events;
+using GxMcp.Worker.Helpers;
+using Microsoft.Practices.CompositeUI.EventBroker;
+using Xunit;
+
+namespace GxMcp.Worker.Tests
+{
+    [Collection("SDK event suspension")]
+    public sealed class SdkEventSuppressionAsyncTests
+    {
+        private const string PublisherTopic = "event://GxMcp/NoKbAsyncIsolation/Publisher";
+        private const string BackgroundTopic = "event://GxMcp/NoKbAsyncIsolation/Background";
+
+        [Fact]
+        public void UiWorkQueuedBeforeSuspension_IsNotCanceledByTheBrokerSwitch()
+        {
+            var global = EventsService.Events;
+            Assert.False(global.EventsSuspended);
+            var context = new QueuedContext();
+            var receiver = new Receiver(context);
+            using var receiverSignal = receiver.Changed;
+            var publisher = new GlobalPublisher();
+            using (global.ScopedParticipation(publisher))
+            using (global.ScopedParticipation(receiver))
+            {
+                publisher.Raise(false);
+                Assert.Equal(1, receiver.Count);
+                Assert.Equal(1, context.PostCount);
+                Assert.Equal(0, receiver.UiCount);
+                using (new SdkEventSuppressionScope())
+                {
+                    // The switch prevents new broker publications. It cannot
+                    // retract work that an earlier handler has already queued.
+                    context.Drain();
+                    Assert.Equal(1, receiver.UiCount);
+                    publisher.Raise(false);
+                    AssertQuiet(receiver, context, 1);
+                }
+            }
+            Assert.False(global.EventsSuspended);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void SuspendedPublication_DoesNotDispatchOrQueueUiWork(bool background, bool kbBroker)
+        {
+            // This SDK exposes Publisher and Background, not a UserInterface
+            // ThreadOption. Model deferred UI work with a controlled context.
+            var global = EventsService.Events;
+            Assert.False(global.EventsSuspended);
+            var broker = kbBroker ? CreateSecondaryBroker() : global;
+            var context = new QueuedContext();
+            var receiver = new Receiver(context);
+            using var receiverSignal = receiver.Changed;
+            object publisher = kbBroker ? (object)new KbPublisher() : new GlobalPublisher();
+            Action raise = kbBroker
+                ? (Action)(() => ((KbPublisher)publisher).Raise(background))
+                : () => ((GlobalPublisher)publisher).Raise(background);
+
+            using (broker.ScopedParticipation(publisher))
+            using (broker.ScopedParticipation(receiver))
+            {
+                raise();
+                Assert.True(receiver.Changed.Wait(2000),
+                    "The enabled SDK broker did not deliver the initial publication.");
+                Assert.Equal(1, receiver.Count);
+                Assert.Equal(1, context.PostCount);
+                Assert.Equal(0, receiver.UiCount);
+                context.Drain();
+                Assert.Equal(1, receiver.UiCount);
+
+                using (new SdkEventSuppressionScope(kbBroker ? broker : null))
+                {
+                    raise();
+                    AssertQuiet(receiver, context, 1);
+                }
+                // Includes a bounded asynchronous observation after resumption:
+                // a suppressed event must not be replayed or enqueue UI work.
+                AssertQuiet(receiver, context, 1);
+
+                raise();
+                Assert.True(receiver.Changed.Wait(2000),
+                    "The SDK broker did not resume delivery after the scope.");
+                Assert.Equal(2, receiver.Count);
+                Assert.Equal(2, context.PostCount);
+                context.Drain();
+                Assert.Equal(2, receiver.UiCount);
+                AssertQuiet(receiver, context, 2);
+            }
+            Assert.False(global.EventsSuspended);
+            Assert.False(broker.EventsSuspended);
+        }
+
+        private static EventsService CreateSecondaryBroker()
+        {
+            // Diagnostic broker only: never instantiate or open a KnowledgeBase.
+            var constructor = typeof(EventsService).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic,
+                null, new[] { typeof(string), typeof(Type), typeof(Type) }, null);
+            Assert.NotNull(constructor);
+            return (EventsService)constructor.Invoke(new object[] {
+                "GxMcp.AsyncIsolationProbe", typeof(KBEventPublicationAttribute), typeof(KBEventArgs) });
+        }
+
+        private static void AssertQuiet(Receiver receiver, QueuedContext context, int expected)
+        {
+            receiver.Changed.Reset();
+            Assert.Equal(expected, receiver.Count);
+            Assert.Equal(expected, context.PostCount);
+            Assert.False(receiver.Changed.Wait(250), "An unexpected asynchronous SDK callback was delivered.");
+            Assert.Equal(expected, receiver.Count);
+            Assert.Equal(expected, context.PostCount);
+            context.Drain();
+            Assert.Equal(expected, receiver.UiCount);
+        }
+
+        public sealed class GlobalPublisher
+        {
+            [EventPublication(PublisherTopic)] public event EventHandler PublisherSignal;
+            [EventPublication(BackgroundTopic)] public event EventHandler BackgroundSignal;
+            public void Raise(bool background)
+            {
+                if (background) BackgroundSignal?.Invoke(this, EventArgs.Empty);
+                else PublisherSignal?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public sealed class KbPublisher
+        {
+            [KBEventPublication(PublisherTopic)] public event EventHandler<KBEventArgs> PublisherSignal;
+            [KBEventPublication(BackgroundTopic)] public event EventHandler<KBEventArgs> BackgroundSignal;
+            public void Raise(bool background)
+            {
+                if (background) BackgroundSignal?.Invoke(this, new KBEventArgs(null));
+                else PublisherSignal?.Invoke(this, new KBEventArgs(null));
+            }
+        }
+
+        public sealed class Receiver
+        {
+            private readonly SynchronizationContext _context;
+            private int _count;
+            private int _uiCount;
+            public Receiver(SynchronizationContext context) { _context = context; }
+            public readonly ManualResetEventSlim Changed = new ManualResetEventSlim();
+            public int Count => Volatile.Read(ref _count);
+            public int UiCount => Volatile.Read(ref _uiCount);
+            [EventSubscription(PublisherTopic, ThreadOption.Publisher)]
+            public void PublisherReceive(object sender, EventArgs args) => Receive();
+            [EventSubscription(BackgroundTopic, ThreadOption.Background)]
+            public void BackgroundReceive(object sender, EventArgs args) => Receive();
+            private void Receive()
+            {
+                Interlocked.Increment(ref _count);
+                _context.Post(_ => Interlocked.Increment(ref _uiCount), null);
+                Changed.Set();
+            }
+        }
+
+        private sealed class QueuedContext : SynchronizationContext
+        {
+            private readonly ConcurrentQueue<Action> _queue = new ConcurrentQueue<Action>();
+            private int _posts;
+            public int PostCount => Volatile.Read(ref _posts);
+            public override void Post(SendOrPostCallback callback, object state)
+            {
+                _queue.Enqueue(() => callback(state));
+                Interlocked.Increment(ref _posts);
+            }
+            public void Drain()
+            {
+                while (_queue.TryDequeue(out var callback)) callback();
+            }
+        }
+    }
+}

--- a/src/GxMcp.Worker.Tests/SdkEventSuppressionScopeTests.cs
+++ b/src/GxMcp.Worker.Tests/SdkEventSuppressionScopeTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Reflection;
+using Artech.Architecture.Common.Events;
+using GxMcp.Worker.Helpers;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GxMcp.Worker.Tests
+{
+    [CollectionDefinition("SDK event suspension", DisableParallelization = true)]
+    public sealed class SdkEventSuppressionCollection { }
+
+    [Collection("SDK event suspension")]
+    public sealed class SdkEventSuppressionScopeTests
+    {
+        [Fact]
+        public void GlobalBroker_SuppressesAndResumesSyntheticCallback_WithoutKb()
+        {
+            var result = SdkEventSuppressionScope.VerifyBroker(null);
+            Assert.True(result["globalBrokerVerified"].Value<bool>());
+            Assert.False(result["kbBrokerVerified"].Value<bool>());
+            Assert.False(EventsService.Events.EventsSuspended);
+        }
+
+        [Fact]
+        public void SecondaryKbPublicationBroker_IsSuppressedByGlobalSwitch_WithoutKb()
+        {
+            // Construction is diagnostic only; production uses the public kb.Events.
+            var constructor = typeof(EventsService).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic,
+                null, new[] { typeof(string), typeof(Type), typeof(Type) }, null);
+            var broker = (EventsService)constructor.Invoke(new object[] {
+                "GxMcp.SecondaryProbe", typeof(KBEventPublicationAttribute), typeof(KBEventArgs) });
+            var result = SdkEventSuppressionScope.VerifyBrokers(broker, null);
+            Assert.True(result["kbBrokerVerified"].Value<bool>());
+            Assert.False(broker.EventsSuspended);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ExceptionAndNestedScopes_RestoreOriginalGlobalState(bool original)
+        {
+            var global = EventsService.Events;
+            bool prior = global.EventsSuspended;
+            try
+            {
+                global.EventsSuspended = original;
+                Assert.Throws<InvalidOperationException>((Action)(() => {
+                    using (new SdkEventSuppressionScope())
+                    using (new SdkEventSuppressionScope())
+                    { Assert.True(global.EventsSuspended); throw new InvalidOperationException("synthetic"); }
+                }));
+                Assert.Equal(original, global.EventsSuspended);
+            }
+            finally { global.EventsSuspended = prior; }
+        }
+
+        [Fact]
+        public void Probe_RejectsAlreadySuspendedBrokerWithoutChangingIt()
+        {
+            var global = EventsService.Events;
+            bool prior = global.EventsSuspended;
+            try
+            {
+                global.EventsSuspended = true;
+                Assert.Throws<InvalidOperationException>(() => SdkEventSuppressionScope.VerifyBroker(null));
+                Assert.True(global.EventsSuspended);
+            }
+            finally { global.EventsSuspended = prior; }
+        }
+    }
+}

--- a/src/GxMcp.Worker.Tests/TypeIntrospectServiceTests.cs
+++ b/src/GxMcp.Worker.Tests/TypeIntrospectServiceTests.cs
@@ -6,6 +6,19 @@ namespace GxMcp.Worker.Tests
 {
     public class TypeIntrospectServiceTests
     {
+        private sealed class FakeDomain
+        {
+            public System.Collections.Generic.List<FakeEnumValue> EnumValues { get; } =
+                new System.Collections.Generic.List<FakeEnumValue>();
+        }
+
+        private sealed class FakeEnumValue
+        {
+            public string Name { get; set; }
+            public string Value { get; set; }
+            public string Description { get; set; }
+        }
+
         [Fact]
         public void ComputeNumericRange_8_0_Unsigned_Is_99999999()
         {
@@ -116,12 +129,43 @@ namespace GxMcp.Worker.Tests
         }
 
         [Fact]
+        public void ReadDomainEnumValues_UsesDirectSdkEnumerationShape()
+        {
+            var domain = new FakeDomain();
+            domain.EnumValues.Add(new FakeEnumValue
+            {
+                Name = "Queued",
+                Value = "1",
+                Description = "Waiting"
+            });
+
+            var values = TypeIntrospectService.ReadDomainEnumValues(domain);
+
+            var value = Assert.Single(values);
+            Assert.Equal("Queued", value.Name);
+            Assert.Equal("1", value.Value);
+            Assert.Equal("Waiting", value.Description);
+        }
+
+        [Fact]
         public void Run_UnknownAction_ReturnsError()
         {
             var svc = new TypeIntrospectService(null, null);
             var json = svc.Run(new JObject { ["action"] = "bogus" });
             var o = JObject.Parse(json);
             Assert.Equal("error", (string)o["status"]);
+            Assert.Equal("InvalidAction", (string)o["error"]?["code"]);
+        }
+
+        [Fact]
+        public void Run_DescribeMissingDomain_ReturnsTypeNotFound()
+        {
+            var svc = new TypeIntrospectService(null, null);
+            var json = svc.Run(new JObject { ["action"] = "describe", ["name"] = "MissingDomain" });
+            var o = JObject.Parse(json);
+            Assert.Equal("error", (string)o["status"]);
+            Assert.Equal("TypeNotFound", (string)o["error"]?["code"]);
+            Assert.Contains("MissingDomain", (string)o["error"]?["message"]);
         }
 
         [Fact]

--- a/src/GxMcp.Worker.Tests/XmlEquivalenceTests.cs
+++ b/src/GxMcp.Worker.Tests/XmlEquivalenceTests.cs
@@ -55,6 +55,22 @@ namespace GxMcp.Worker.Tests
         }
 
         [Fact]
+        public void EmptyWebComponentParametersInjectedBySdkAreEquivalent()
+        {
+            var persisted = "<instance><table><webComponent name='SelectorComponent' gxobject='type-WC'><parameters /></webComponent></table></instance>";
+            var requested = "<instance><table><webComponent name='SelectorComponent' gxobject='type-WC' /></table></instance>";
+            Assert.True(XmlEquivalence.AreEquivalent(persisted, requested, out var diff), diff);
+        }
+
+        [Fact]
+        public void NonEmptyWebComponentParametersRemainStrict()
+        {
+            var persisted = "<instance><table><webComponent name='SelectorComponent' gxobject='type-WC'><parameters><parameter name='&amp;Id' /></parameters></webComponent></table></instance>";
+            var requested = "<instance><table><webComponent name='SelectorComponent' gxobject='type-WC' /></table></instance>";
+            Assert.False(XmlEquivalence.AreEquivalent(persisted, requested, out _));
+        }
+
+        [Fact]
         public void ElementNameDifferenceIsDetected()
         {
             var a = "<r><a/></r>";

--- a/src/GxMcp.Worker/GxMcp.Worker.csproj
+++ b/src/GxMcp.Worker/GxMcp.Worker.csproj
@@ -19,6 +19,7 @@
 
   <PropertyGroup>
     <GX_PATH Condition="'$(GX_PATH)' == ''">C:\Program Files (x86)\GeneXus\GeneXus18</GX_PATH>
+    <GxMcpSdkManifest Condition="'$(GxMcpSdkManifest)' == ''">$(MSBuildProjectDirectory)\..\..\config\sdk-compatibility.json</GxMcpSdkManifest>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GxMcpSkipSdkValidation)' == ''">
@@ -26,11 +27,11 @@
   </PropertyGroup>
 
   <Target Name="ValidateGeneXusSdk" BeforeTargets="ResolveAssemblyReferences" Condition="'$(GxMcpSkipSdkValidation)' != 'true'">
-    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\..\..\scripts\validate-gx-sdk.ps1&quot; -GxPath &quot;$(GX_PATH)&quot; -Manifest &quot;$(MSBuildProjectDirectory)\..\..\config\sdk-compatibility.json&quot;" />
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\..\..\scripts\validate-gx-sdk.ps1&quot; -GxPath &quot;$(GX_PATH)&quot; -Manifest &quot;$(GxMcpSdkManifest)&quot;" />
   </Target>
 
   <ItemGroup>
-    <None Include="..\..\config\sdk-compatibility.json" Link="sdk-compatibility.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(GxMcpSdkManifest)" Link="sdk-compatibility.json" TargetPath="sdk-compatibility.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <PropertyGroup Condition="Exists('$(GX_PATH)\GeneXus.SecurityScanner.Common.dll')">

--- a/src/GxMcp.Worker/Helpers/DomainPropertyApplier.cs
+++ b/src/GxMcp.Worker/Helpers/DomainPropertyApplier.cs
@@ -247,7 +247,10 @@ namespace GxMcp.Worker.Helpers
             {
                 object enumValues = AttributeTypeApplier.GetPropertyUnambiguous(domain.GetType(), "EnumValues")
                     ?.GetValue(domain, null);
-                object values = enumValues == null ? null
+                if (enumValues == null) enumValues = InvokePropertyBagGetEnumValues(domain);
+                object values = enumValues is IEnumerable
+                    ? enumValues
+                    : enumValues == null ? null
                     : AttributeTypeApplier.GetPropertyUnambiguous(enumValues.GetType(), "Values")?.GetValue(enumValues, null);
                 if (!(values is IEnumerable enumerable)) return result;
                 foreach (object item in enumerable)
@@ -281,10 +284,29 @@ namespace GxMcp.Worker.Helpers
             catch { return false; }
         }
 
+        private static object InvokePropertyBagGetEnumValues(object domain)
+        {
+            var mi = _getEnumValuesMethod;
+            if (mi == null)
+            {
+                mi = ResolveGetEnumValuesMethod();
+                _getEnumValuesMethod = mi;
+            }
+            if (mi == null) return null;
+            try { return mi.Invoke(null, new[] { domain }); }
+            catch { return null; }
+        }
+
         private static MethodInfo ResolveSetEnumValuesMethod()
         {
             var attType = ResolveType("Artech.Genexus.Common.Properties+ATT");
             return attType?.GetMethod("SetEnumValues", BindingFlags.Public | BindingFlags.Static);
+        }
+
+        private static MethodInfo ResolveGetEnumValuesMethod()
+        {
+            var attType = ResolveType("Artech.Genexus.Common.Properties+ATT");
+            return attType?.GetMethod("GetEnumValues", BindingFlags.Public | BindingFlags.Static);
         }
 
         private static Type ResolveType(string fullName)
@@ -332,5 +354,6 @@ namespace GxMcp.Worker.Helpers
             new ConcurrentDictionary<string, Type>(StringComparer.Ordinal);
 
         private static MethodInfo _setEnumValuesMethod;
+        private static MethodInfo _getEnumValuesMethod;
     }
 }

--- a/src/GxMcp.Worker/Helpers/EventsSaveIsolation.cs
+++ b/src/GxMcp.Worker/Helpers/EventsSaveIsolation.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using Artech.Architecture.Common.Objects;
+using Artech.Genexus.Common.Objects;
+using Artech.Genexus.Common.Parts;
+using Artech.Packages.Patterns.Objects;
+using GxMcp.Worker.Services;
+using Newtonsoft.Json.Linq;
+
+namespace GxMcp.Worker.Helpers
+{
+    internal static class EventsSaveIsolation
+    {
+        // Only the inspected U16 implementation is eligible. Broker suppression
+        // cannot disable virtual methods or native Entity.BeforeSave delegates.
+        private static readonly Dictionary<string, string> AuditedAssemblies = new Dictionary<string, string>
+        {
+            ["Artech.Architecture.Common"] = "5de4b9fa160b2aca8fa08be8e070870c00286415d7ecdfad816aa5bdc406f283",
+            ["Artech.Genexus.Common"] = "9e1faca2f240141794c6627f22e71e4d8acd8f1a8a9daaea3b2d4254515e95f0",
+            ["Artech.Udm.Framework"] = "ba47b86818aff828a5172b44c0ea83353b4a565fec076105480a995535bc9251",
+            ["Artech.Common.Properties"] = "615ca8e522142748feb4a467081efdcd57d962ad71382dc2d77e2639f91a990a",
+            ["Artech.Packages.Patterns"] = "36f99d7d76c3c7b54dded1249d09a02234834c9d38483c68afc9d79bd8538ace",
+            ["DVelop.Patterns.WorkWithPlus"] = "16e15bcb8eaef779abd5b8ef9d33c724f58406979496612a253473688b52fb02"
+        };
+        private static readonly HashSet<Type> Parts = new HashSet<Type>
+        {
+            typeof(EventsPart), typeof(WebFormPart), typeof(VariablesPart), typeof(RulesPart),
+            typeof(ConditionsPart), typeof(HelpPart), typeof(DocumentationPart),
+            typeof(PatternVirtualPart)
+        };
+
+        internal static JObject Preflight(KBObject obj)
+        {
+            CheckTarget(obj);
+            var fresh = Fresh(obj.KB, obj.Guid);
+            var report = CheckTarget(fresh);
+            report["brokers"] = SdkEventSuppressionScope.VerifyBroker(fresh.KB);
+            report["freshInstanceVerified"] = true;
+            report["verified"] = true;
+            return report;
+        }
+
+        internal static JObject CheckTarget(KBObject obj)
+        {
+            if (obj == null || obj.GetType() != typeof(WebPanel))
+                throw new InvalidOperationException("Isolated Events save supports only the exact audited SDK WebPanel type.");
+            if (!WriteDestinationGuard.IsConfigured)
+                throw new InvalidOperationException("Isolated Events save requires both profile-owned KB and version pins.");
+            var kb = obj.KB;
+            var version = KBVersion.GetActive(kb);
+            string destinationError = WriteDestinationGuard.Check(
+                Environment.GetEnvironmentVariable(WriteDestinationGuard.PathVariable),
+                Environment.GetEnvironmentVariable(WriteDestinationGuard.VersionVariable),
+                kb.Location, version?.Name, version == null ? (bool?)null : version.IsFrozen, false);
+            if (destinationError != null) throw new InvalidOperationException(destinationError);
+            foreach (var expected in AuditedAssemblies)
+            {
+                var assembly = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(a => a.GetName().Name == expected.Key);
+                // WorkWithPlus is loaded only when the target has that package
+                // installed/attached. If loaded, its exact U16 bytes are still
+                // mandatory; an unknown loaded implementation is never trusted.
+                if (assembly == null && expected.Key == "DVelop.Patterns.WorkWithPlus") continue;
+                if (assembly == null || !string.Equals(Hash(File.ReadAllBytes(assembly.Location)), expected.Value, StringComparison.Ordinal))
+                    throw new InvalidOperationException("Unverified SDK implementation: " + expected.Key);
+            }
+            var partTypes = obj.Parts.Cast<KBObjectPart>().Select(p => p.GetType()).ToArray();
+            if (!partTypes.Contains(typeof(EventsPart)) || partTypes.Any(p => !Parts.Contains(p)))
+                throw new InvalidOperationException("The object contains an unverified SDK or extension part: "
+                    + string.Join(", ", partTypes.Where(p => !Parts.Contains(p)).Select(p => p.FullName)));
+            JObject report = new JObject();
+            var callbacks = new JArray();
+            InspectDirectCallbacks(obj, callbacks);
+            foreach (KBObjectPart part in obj.Parts) InspectDirectCallbacks(part, callbacks);
+            report["directCallbacks"] = callbacks;
+            report["sdkFingerprintVerified"] = true;
+            report["objectGuid"] = obj.Guid.ToString();
+            report["parts"] = new JArray(partTypes.Select(p => p.FullName));
+            report["patternPart"] = partTypes.Contains(typeof(PatternVirtualPart));
+            report["skipApplyPatternSupported"] = true;
+            report["wwpAssemblyLoaded"] = AppDomain.CurrentDomain.GetAssemblies()
+                .Any(a => a.GetName().Name == "DVelop.Patterns.WorkWithPlus");
+            report["scope"] = "audited-u16-webpanel-with-pattern-save-isolation";
+            return report;
+        }
+
+        internal static bool IsAllowedPartType(Type type) => Parts.Contains(type);
+        internal static bool IsAllowedPartTypeName(string fullName)
+            => Parts.Any(type => type.FullName == fullName);
+
+        internal static bool IsExpectedPatternProjection(ObjectMoveSnapshot.Comparison comparison)
+        {
+            if (comparison == null || comparison.Equal) return true;
+            foreach (var changed in comparison.ChangedParts)
+            {
+                string name = changed?.ToString();
+                if (!string.Equals(name, "Rules", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(name, "Conditions", StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+            return comparison.ChangedParts.Count > 0;
+        }
+
+        internal static void InspectDirectCallbacks(object instance, JArray report)
+        {
+            for (Type type = instance.GetType(); type != null; type = type.BaseType)
+            {
+                foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly))
+                {
+                    if (!typeof(Delegate).IsAssignableFrom(field.FieldType)) continue;
+                    var value = field.GetValue(instance) as Delegate;
+                    if (value == null) continue;
+                    foreach (var callback in value.GetInvocationList())
+                    {
+                        string declaringAssembly = callback.Method.DeclaringType?.Assembly.GetName().Name;
+                        string targetAssembly = callback.Target?.GetType().Assembly.GetName().Name;
+                        string handler = callback.Method.DeclaringType?.FullName + "." + callback.Method.Name;
+                        if (declaringAssembly == null || !AuditedAssemblies.ContainsKey(declaringAssembly)
+                            || (targetAssembly != null && !AuditedAssemblies.ContainsKey(targetAssembly)))
+                            throw new InvalidOperationException("An unverified direct SDK callback is attached to "
+                                + instance.GetType().FullName + ": " + handler + " (target assembly: " + targetAssembly + ").");
+                        report.Add(new JObject { ["ownerType"] = instance.GetType().FullName, ["handler"] = handler });
+                    }
+                }
+            }
+        }
+
+        internal static KBObject Fresh(KnowledgeBase kb, Guid guid)
+        {
+            var seed = kb.DesignModel.Objects.Get(guid) ?? throw new InvalidOperationException("Object not found by GUID.");
+            var cache = kb.DesignModel.Objects as IKBModelObjectsCacheConfiguration
+                ?? throw new InvalidOperationException("SDK public object-cache configuration is unavailable.");
+            cache.Invalidate(seed);
+            cache.RemoveFromCaches(seed);
+            var fresh = kb.DesignModel.Objects.Get(seed.Key) ?? throw new InvalidOperationException("SDK fresh object lookup failed.");
+            if (fresh.Guid != guid || ReferenceEquals(seed, fresh))
+                throw new InvalidOperationException("SDK did not return a new instance of the requested GUID after cache removal.");
+            return fresh;
+        }
+
+        internal static string Source(KBObject obj)
+        {
+            var part = GxMcp.Worker.Structure.PartAccessor.GetPart(obj, "Events") as ISource;
+            return part?.Source ?? string.Empty;
+        }
+
+        internal static string Token(KBObject obj)
+            => WriteService.ComputeContentVersionToken(obj, Source(obj));
+
+        internal static string ContentHash(string value)
+        {
+            using (var sha = SHA256.Create())
+                return BitConverter.ToString(sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(value ?? string.Empty)))
+                    .Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        internal static bool SourceEquivalent(string left, string right)
+            => NormalizeSource(left) == NormalizeSource(right);
+
+        private static string NormalizeSource(string value)
+            => (value ?? string.Empty).Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd('\n');
+
+        internal static string Placement(KBObject obj) => obj.Parent?.Guid.ToString() ?? "root";
+
+        internal static Dictionary<Guid, string> Inventory(KnowledgeBase kb)
+        {
+            var ids = kb.DesignModel.Objects.Cast<KBObject>().Select(o => o.Guid).ToArray();
+            var result = new Dictionary<Guid, string>();
+            foreach (Guid guid in ids)
+            {
+                var obj = Fresh(kb, guid);
+                result.Add(guid, obj.VersionId.ToString(CultureInfo.InvariantCulture) + ":"
+                    + obj.LastUpdate.ToUniversalTime().Ticks.ToString(CultureInfo.InvariantCulture) + ":"
+                    + obj.Parent?.Guid.ToString() + ":" + obj.Name + ":" + obj.TypeDescriptor.Id);
+            }
+            return result;
+        }
+
+        internal static JArray ChangedOthers(Dictionary<Guid, string> before, Dictionary<Guid, string> after, Guid target)
+            => new JArray(before.Keys.Concat(after.Keys).Distinct().Where(g => g != target
+                && (!before.ContainsKey(g) || !after.ContainsKey(g) || before[g] != after[g])).Select(g => g.ToString()));
+
+        private static string Hash(byte[] value)
+        {
+            using (var sha = SHA256.Create())
+                return BitConverter.ToString(sha.ComputeHash(value)).Replace("-", "").ToLowerInvariant();
+        }
+    }
+}

--- a/src/GxMcp.Worker/Helpers/ObjectMoveSnapshot.cs
+++ b/src/GxMcp.Worker/Helpers/ObjectMoveSnapshot.cs
@@ -132,6 +132,36 @@ namespace GxMcp.Worker.Helpers
                 : Comparison.Failed(changed, current.Hash, changedKeys);
         }
 
+        internal JArray DescribeDifferences(KBObject obj, params string[] ignoredPartNames)
+        {
+            var result = new JArray();
+            if (obj == null) return result;
+
+            ObjectMoveSnapshot current;
+            try { current = Capture(obj); }
+            catch { return result; }
+
+            var ignored = new HashSet<string>(ignoredPartNames ?? new string[0], StringComparer.OrdinalIgnoreCase);
+            foreach (string key in FindChangedPartKeys(
+                _parts.Where(p => !ignored.Contains(p.Value.Name)).ToDictionary(p => p.Key, p => p.Value.VerificationData, StringComparer.OrdinalIgnoreCase),
+                current._parts.Where(p => !ignored.Contains(p.Value.Name)).ToDictionary(p => p.Key, p => p.Value.VerificationData, StringComparer.OrdinalIgnoreCase)))
+            {
+                _parts.TryGetValue(key, out var before);
+                current._parts.TryGetValue(key, out var after);
+                result.Add(new JObject
+                {
+                    ["part"] = before?.Name ?? after?.Name ?? key,
+                    ["beforeFormat"] = before?.Format,
+                    ["afterFormat"] = after?.Format,
+                    ["beforeLength"] = before?.VerificationData?.Length ?? 0,
+                    ["afterLength"] = after?.VerificationData?.Length ?? 0,
+                    ["beforeHash"] = before == null ? null : HashBytes(before.VerificationData),
+                    ["afterHash"] = after == null ? null : HashBytes(after.VerificationData)
+                });
+            }
+            return result;
+        }
+
         /// <summary>
         /// Compensating restoration used only when the enclosing SDK transaction did not
         /// fully undo a failed move. The normal rollback path is the transaction rollback.
@@ -292,6 +322,11 @@ namespace GxMcp.Worker.Helpers
             var sb = new StringBuilder(bytes.Length * 2);
             foreach (byte b in bytes) sb.Append(b.ToString("x2"));
             return sb.ToString();
+        }
+
+        private static string HashBytes(byte[] bytes)
+        {
+            using (var sha = SHA256.Create()) return ToHex(sha.ComputeHash(bytes ?? new byte[0]));
         }
 
         private static byte[] SerializeEntityData(object entity)

--- a/src/GxMcp.Worker/Helpers/PatternSaveIsolationScope.cs
+++ b/src/GxMcp.Worker/Helpers/PatternSaveIsolationScope.cs
@@ -1,0 +1,54 @@
+using System;
+using Artech.Architecture.Common.Objects;
+
+namespace GxMcp.Worker.Helpers
+{
+    // PatternVirtualPart is a virtual SDK part. Its normal after-save handler
+    // may apply a pattern, so a complete Events save must explicitly suppress
+    // that handler and prove the flag was restored afterwards.
+    internal sealed class PatternSaveIsolationScope : IDisposable
+    {
+        internal const string SkipApplyPatternFlag = "SkipApplyPattern";
+        private readonly KBObject _object;
+        private readonly bool _before;
+        private bool _disposed;
+
+        internal PatternSaveIsolationScope(KBObject obj)
+        {
+            _object = obj ?? throw new ArgumentNullException(nameof(obj));
+            try
+            {
+                _before = _object.Flags.Get<bool>(SkipApplyPatternFlag);
+                _object.Flags[SkipApplyPatternFlag] = true;
+                if (!_object.Flags.Get<bool>(SkipApplyPatternFlag))
+                    throw new InvalidOperationException("SDK did not accept SkipApplyPattern=true.");
+            }
+            catch
+            {
+                SdkEventSuppressionScope.Poison();
+                throw;
+            }
+        }
+
+        internal bool WasAlreadySet => _before;
+        internal bool Restored { get; private set; }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try
+            {
+                _object.Flags[SkipApplyPatternFlag] = _before;
+                if (_object.Flags.Get<bool>(SkipApplyPatternFlag) != _before)
+                    throw new InvalidOperationException("SDK did not restore SkipApplyPattern.");
+                Restored = true;
+            }
+            catch
+            {
+                SdkEventSuppressionScope.Poison();
+                throw;
+            }
+        }
+    }
+}

--- a/src/GxMcp.Worker/Helpers/PatternXmlEditPlan.cs
+++ b/src/GxMcp.Worker/Helpers/PatternXmlEditPlan.cs
@@ -67,6 +67,8 @@ namespace GxMcp.Worker.Helpers
             var newNodes = after.Nodes().Where(Significant).ToArray();
             if (oldNodes.Length != newNodes.Length)
             {
+                if (TryAllowWebComponentInsertion(before, after, oldNodes, newNodes, path))
+                    return;
                 Reject("PatternStructureChangeUnsupported", "Child structure changed at " + path);
                 return;
             }
@@ -83,6 +85,62 @@ namespace GxMcp.Worker.Helpers
                     Reject("PatternStructureChangeUnsupported", "Text or node structure changed at " + path);
                 if (ErrorCode != null) return;
             }
+        }
+
+        // A WebComponent is a named, non-ordered child in WorkWithPlus layout
+        // containers. Allow only the narrow structural operation needed to add
+        // one such component to an existing container: no removals, moves,
+        // replacements, metadata changes, or childrenOrderedList edits. The
+        // normal PatternInstance SDK deserializer/save path still performs the
+        // actual persistence and the later WWP projection verifies the result.
+        private bool TryAllowWebComponentInsertion(XElement before, XElement after,
+            XNode[] oldNodes, XNode[] newNodes, string path)
+        {
+            if (!string.Equals(before.Name.LocalName, "table", StringComparison.OrdinalIgnoreCase)
+                || newNodes.Length != oldNodes.Length + 1)
+                return false;
+
+            int insertedIndex = -1;
+            for (int i = 0; i < newNodes.Length; i++)
+            {
+                if (!(newNodes[i] is XElement element)
+                    || !string.Equals(element.Name.LocalName, "webComponent", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (insertedIndex >= 0) return false;
+                insertedIndex = i;
+            }
+            if (insertedIndex < 0) return false;
+
+            var inserted = (XElement)newNodes[insertedIndex];
+            if (inserted.HasElements
+                || inserted.Attributes().Any(a => !string.Equals(a.Name.LocalName, "name", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(a.Name.LocalName, "gxobject", StringComparison.OrdinalIgnoreCase)))
+                return false;
+
+            string name = (string)inserted.Attribute("name");
+            string gxobject = (string)inserted.Attribute("gxobject");
+            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(gxobject))
+                return false;
+
+            int oldIndex = 0;
+            for (int newIndex = 0; newIndex < newNodes.Length; newIndex++)
+            {
+                if (newIndex == insertedIndex) continue;
+                if (oldIndex >= oldNodes.Length || !XNode.DeepEquals(oldNodes[oldIndex], newNodes[newIndex]))
+                    return false;
+                oldIndex++;
+            }
+            if (oldIndex != oldNodes.Length) return false;
+
+            Changes.Add(new JObject
+            {
+                ["path"] = path + "webComponent[@name='" + name + "']",
+                ["operation"] = "Insert",
+                ["after"] = insertedIndex == 0 ? null : "existing child at index " + (insertedIndex - 1),
+                ["name"] = name,
+                ["gxobject"] = gxobject
+            });
+            return true;
         }
 
         private static bool Significant(XNode node) => !(node is XText text)

--- a/src/GxMcp.Worker/Helpers/SdkEventSuppressionScope.cs
+++ b/src/GxMcp.Worker/Helpers/SdkEventSuppressionScope.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Threading;
+using Artech.Architecture.Common.Events;
+using Artech.Architecture.Common.Objects;
+using Microsoft.Practices.CompositeUI.EventBroker;
+using Newtonsoft.Json.Linq;
+
+namespace GxMcp.Worker.Helpers
+{
+    // EventsSuspended is the SDK's public broker switch (also exposed by
+    // ArtechTask). U16 tests show that the GLOBAL switch controls KB brokers;
+    // setting only kb.Events.EventsSuspended does not suppress callbacks.
+    internal sealed class SdkEventSuppressionScope : IDisposable
+    {
+        internal const string Topic = "event://GxMcp/EventsSaveIsolationProbe";
+        internal const string KbTopic = "event://GxMcp/EventsSaveIsolationProbeKb";
+        private static int _activeScopes;
+        private static volatile bool _poisoned;
+        internal static bool IsPoisoned => _poisoned;
+        internal static bool IsActive => _poisoned || Volatile.Read(ref _activeScopes) != 0;
+        internal static void Poison() => _poisoned = true;
+        private readonly EventsService _global;
+        private readonly EventsService _local;
+        private readonly bool _globalBefore;
+        private readonly bool _localBefore;
+        private bool _disposed;
+
+        internal SdkEventSuppressionScope(EventsService local = null)
+        {
+            _global = EventsService.Events ?? throw new InvalidOperationException("SDK global event broker unavailable.");
+            _local = local;
+            _globalBefore = _global.EventsSuspended;
+            _localBefore = _local?.EventsSuspended ?? false;
+            Interlocked.Increment(ref _activeScopes);
+            try
+            {
+                _global.EventsSuspended = true;
+                if (_local != null) _local.EventsSuspended = true;
+                if (!_global.EventsSuspended) throw new InvalidOperationException("SDK event suspension was not accepted.");
+            }
+            catch { Dispose(); throw; }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try
+            {
+                try { if (_local != null) _local.EventsSuspended = _localBefore; }
+                finally { _global.EventsSuspended = _globalBefore; }
+                if (_global.EventsSuspended != _globalBefore || (_local != null && _local.EventsSuspended != _localBefore))
+                    throw new InvalidOperationException("SDK event broker state could not be restored.");
+            }
+            catch { _poisoned = true; throw; }
+            finally { Interlocked.Decrement(ref _activeScopes); }
+        }
+
+        // Publishes an isolated synthetic topic, never a GeneXus lifecycle event.
+        // The real KB instance is required for the KB broker's argument filter.
+        internal static JObject VerifyBroker(KnowledgeBase kb)
+            => VerifyBrokers(kb?.Events, kb);
+
+        internal static JObject VerifyBrokers(EventsService local, KnowledgeBase kb)
+        {
+            var global = EventsService.Events;
+            if (global == null || global.EventsSuspended || (local != null && local.EventsSuspended))
+                throw new InvalidOperationException("The event brokers must be active before the isolation preflight.");
+            var globalPublisher = new GlobalPublisher();
+            var kbPublisher = new KbPublisher(kb);
+            var globalReceiver = new Receiver();
+            var kbReceiver = new KbReceiver();
+            using (global.ScopedParticipation(globalPublisher))
+            using (global.ScopedParticipation(globalReceiver))
+            using (local?.ScopedParticipation(kbPublisher))
+            using (local?.ScopedParticipation(kbReceiver))
+            {
+                globalPublisher.Raise();
+                if (local != null) kbPublisher.Raise();
+                AssertCounts(globalReceiver, kbReceiver, local != null, 1);
+                using (new SdkEventSuppressionScope(local))
+                {
+                    globalPublisher.Raise();
+                    if (local != null) kbPublisher.Raise();
+                    AssertCounts(globalReceiver, kbReceiver, local != null, 1);
+                }
+                // Resumption must not replay the suppressed publication.
+                AssertCounts(globalReceiver, kbReceiver, local != null, 1);
+                globalPublisher.Raise();
+                if (local != null) kbPublisher.Raise();
+                AssertCounts(globalReceiver, kbReceiver, local != null, 2);
+            }
+            return new JObject
+            {
+                ["globalBrokerVerified"] = true, ["kbBrokerVerified"] = local != null,
+                ["callbacksBeforeDuringAfter"] = new JArray(1, 1, 2),
+                ["brokerStateRestored"] = true, ["sdkSaveAttempted"] = false
+            };
+        }
+
+        private static void AssertCounts(Receiver global, KbReceiver local, bool hasLocal, int expected)
+        {
+            if (global.Count != expected || (hasLocal && local.Count != expected))
+                throw new InvalidOperationException("The SDK event broker failed the normal/suspended/resumed callback test.");
+        }
+
+        public sealed class GlobalPublisher
+        {
+            [EventPublication(Topic)] public event EventHandler Signal;
+            public void Raise() => Signal?.Invoke(this, EventArgs.Empty);
+        }
+
+        public sealed class KbPublisher
+        {
+            private readonly KnowledgeBase _kb;
+            public KbPublisher(KnowledgeBase kb) { _kb = kb; }
+            [KBEventPublication(KbTopic)] public event EventHandler<KBEventArgs> Signal;
+            public void Raise() => Signal?.Invoke(this, new KBEventArgs(_kb));
+        }
+
+        public sealed class Receiver
+        {
+            public int Count;
+            [EventSubscription(Topic, ThreadOption.Publisher)]
+            public void Receive(object sender, EventArgs args) { Count++; }
+        }
+
+        public sealed class KbReceiver
+        {
+            public int Count;
+            [EventSubscription(KbTopic, ThreadOption.Publisher)]
+            public void Receive(object sender, EventArgs args) { Count++; }
+        }
+    }
+}

--- a/src/GxMcp.Worker/Helpers/XmlEquivalence.cs
+++ b/src/GxMcp.Worker/Helpers/XmlEquivalence.cs
@@ -46,6 +46,17 @@ namespace GxMcp.Worker.Helpers
             catch (Exception ex) { diffSummary = "Right parse error: " + ex.Message; structuredDiff = new XmlEquivalenceDiff { Summary = diffSummary }; return false; }
 
             var ok = ElementsEqual(da.Root, db.Root, "/", out diffSummary, out structuredDiff);
+            // WorkWithPlus materializes an empty Parameters node for a
+            // WebComponent control even when the author omitted it. This is a
+            // canonical SDK projection, not a rejected authored child. Accept
+            // only that exact normalization; substantive children and all
+            // other structure remain strict.
+            if (!ok && WwpEmptyWebComponentParametersEquivalent(da.Root, db.Root))
+            {
+                diffSummary = null;
+                structuredDiff = null;
+                return true;
+            }
             // Report-layout projection: the persisted <Report> is a SUPERSET of the request
             // (the projection re-emits SDK defaults like BorderStyle/ForeColor that the
             // caller never sent). Only accept requested⊆persisted — never the reverse, or
@@ -59,6 +70,43 @@ namespace GxMcp.Worker.Helpers
             if (!ok && structuredDiff == null)
                 structuredDiff = new XmlEquivalenceDiff { Summary = diffSummary };
             return ok;
+        }
+
+        private static bool WwpEmptyWebComponentParametersEquivalent(XElement persisted, XElement requested)
+        {
+            if (persisted == null || requested == null) return false;
+            var persistedCopy = new XElement(persisted);
+            var requestedCopy = new XElement(requested);
+            bool hasWebComponent = persistedCopy.Descendants()
+                .Concat(requestedCopy.Descendants())
+                .Any(e => e.Name.LocalName.Equals("webComponent", StringComparison.OrdinalIgnoreCase));
+            if (!hasWebComponent) return false;
+
+            bool removed = RemoveImplicitParameters(persistedCopy) | RemoveImplicitParameters(requestedCopy);
+            if (!removed) return false;
+
+            return ElementsEqual(persistedCopy, requestedCopy, "/", out _, out _);
+        }
+
+        private static bool RemoveImplicitParameters(XElement root)
+        {
+            bool removed = false;
+            foreach (var component in root.Descendants()
+                .Where(e => e.Name.LocalName.Equals("webComponent", StringComparison.OrdinalIgnoreCase)))
+            {
+                foreach (var parameters in component.Elements()
+                    .Where(e => e.Name.LocalName.Equals("parameters", StringComparison.OrdinalIgnoreCase))
+                    .ToList())
+                {
+                    if (!parameters.HasAttributes && !parameters.HasElements
+                        && !parameters.Nodes().OfType<XText>().Any(t => !string.IsNullOrWhiteSpace(t.Value)))
+                    {
+                        parameters.Remove();
+                        removed = true;
+                    }
+                }
+            }
+            return removed;
         }
 
         /// <summary>

--- a/src/GxMcp.Worker/Program.cs
+++ b/src/GxMcp.Worker/Program.cs
@@ -573,6 +573,9 @@ namespace GxMcp.Worker
 
         private static void DrainSdkCommands()
         {
+            // SDK Save may pump the STA message loop. A nested command or
+            // background job must not run inside another operation's broker scope.
+            if (GxMcp.Worker.Helpers.SdkEventSuppressionScope.IsActive) return;
             while (SdkCommandQueue.TryTake(out string line))
             {
                 Interlocked.Exchange(ref _sdkBusySinceTicks, DateTime.UtcNow.Ticks);
@@ -989,6 +992,8 @@ namespace GxMcp.Worker
                     ["cacheOutcome"] = "unknown"
                 };
                 SendResponse(result, idJson, telemetry);
+                if (GxMcp.Worker.Helpers.SdkEventSuppressionScope.IsPoisoned)
+                    SchedulePoisonedExit();
             } catch (Exception ex) when (GxMcp.Worker.Helpers.WorkerCrashGuard.IsCorruptedState(ex)) {
                 // Native/corrupted-state SDK crash: the heap may be inconsistent, so answer THIS
                 // call with a structured error and then exit — the gateway respawns a fresh worker

--- a/src/GxMcp.Worker/SdkCompatibilityValidator.cs
+++ b/src/GxMcp.Worker/SdkCompatibilityValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using Newtonsoft.Json.Linq;
@@ -38,7 +39,6 @@ namespace GxMcp.Worker
             catch (Exception ex) { return Fail("GXMCP_SDK_MANIFEST_INVALID", "GXMCP_SDK_MANIFEST_INVALID manifest=" + manifestPath + " error=" + ex.GetType().Name); }
 
             string expectedVersion = (string)manifest["supportedVersion"];
-            bool allowPatchVersionDrift = manifest["allowPatchVersionDrift"]?.Value<bool>() ?? false;
             string anchor = (string)manifest["anchor"];
             string anchorPath = Path.Combine(sdkPath, anchor ?? string.Empty);
             if (string.IsNullOrWhiteSpace(anchor) || !File.Exists(anchorPath))
@@ -46,13 +46,13 @@ namespace GxMcp.Worker
 
             string actualVersion = versionReader(anchorPath);
             bool exactVersion = string.Equals(expectedVersion, actualVersion, StringComparison.OrdinalIgnoreCase);
-            bool compatiblePatch = allowPatchVersionDrift && SameMajorMinor(expectedVersion, actualVersion);
-            if (!exactVersion && !compatiblePatch)
+            if (!SameMajor(expectedVersion, actualVersion))
                 return Fail("GXMCP_SDK_VERSION_MISMATCH", "GXMCP_SDK_VERSION_MISMATCH expectedVersion=" + expectedVersion + " actualVersion=" + actualVersion);
 
             var assemblies = manifest["assemblies"] as JArray;
             if (assemblies == null || assemblies.Count == 0)
                 return Fail("GXMCP_SDK_MANIFEST_INVALID", "GXMCP_SDK_MANIFEST_INVALID manifest=" + manifestPath + " error=assemblies");
+            var fingerprintDrift = new List<string>();
             foreach (var token in assemblies)
             {
                 string relativePath = (string)token["path"];
@@ -60,22 +60,22 @@ namespace GxMcp.Worker
                 string filePath = Path.Combine(sdkPath, relativePath ?? string.Empty);
                 if (string.IsNullOrWhiteSpace(relativePath) || !File.Exists(filePath))
                     return Fail("GXMCP_SDK_ASSEMBLY_MISSING", "GXMCP_SDK_ASSEMBLY_MISSING path=" + (relativePath ?? "<missing>"));
-                string actualHash = exactVersion ? Sha256(filePath) : null;
-                if (exactVersion && !string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
-                    return Fail("GXMCP_SDK_FINGERPRINT_MISMATCH", "GXMCP_SDK_FINGERPRINT_MISMATCH path=" + relativePath + " expectedSha256=" + expectedHash + " actualSha256=" + actualHash);
+                string actualHash = Sha256(filePath);
+                if (!string.Equals(expectedHash, actualHash, StringComparison.OrdinalIgnoreCase))
+                    fingerprintDrift.Add("GXMCP_SDK_FINGERPRINT_DRIFT path=" + relativePath + " expectedSha256=" + expectedHash + " actualSha256=" + actualHash);
             }
-            string versionDiagnostic = exactVersion ? expectedVersion : expectedVersion + " actualVersion=" + actualVersion + " (compatible patch drift)";
-            return new SdkCompatibilityResult(true, "GXMCP_SDK_COMPATIBLE", "GXMCP_SDK_COMPATIBLE version=" + versionDiagnostic + " assemblies=" + assemblies.Count);
+            string versionDiagnostic = exactVersion ? expectedVersion : expectedVersion + " actualVersion=" + actualVersion + " (compatible major; patch/build drift)";
+            string diagnostic = "GXMCP_SDK_COMPATIBLE version=" + versionDiagnostic + " assemblies=" + assemblies.Count;
+            if (fingerprintDrift.Count > 0) diagnostic += "\n" + string.Join("\n", fingerprintDrift);
+            return new SdkCompatibilityResult(true, "GXMCP_SDK_COMPATIBLE", diagnostic);
         }
 
-        private static bool SameMajorMinor(string expected, string actual)
+        private static bool SameMajor(string expected, string actual)
         {
             if (string.IsNullOrWhiteSpace(expected) || string.IsNullOrWhiteSpace(actual)) return false;
-            var e = expected.Split('.');
-            var a = actual.Split('.');
-            return e.Length >= 2 && a.Length >= 2
-                && string.Equals(e[0], a[0], StringComparison.Ordinal)
-                && string.Equals(e[1], a[1], StringComparison.Ordinal);
+            return int.TryParse(expected.Split('.')[0], out int expectedMajor)
+                && int.TryParse(actual.Split('.')[0], out int actualMajor)
+                && expectedMajor > 0 && expectedMajor == actualMajor;
         }
 
         private static SdkCompatibilityResult Fail(string code, string diagnostic)

--- a/src/GxMcp.Worker/Services/IndexCacheService.cs
+++ b/src/GxMcp.Worker/Services/IndexCacheService.cs
@@ -1783,20 +1783,16 @@ namespace GxMcp.Worker.Services
             finally { try { if (File.Exists(tmp)) File.Delete(tmp); } catch { } }
         }
 
-        // Returns true when this call wrote a snapshot to disk that is at least as new
-        // as the dirty generation captured before serialization started; false when it
-        // skipped (flush already in flight / no index) or failed. Never throws.
-        //
         // Plan 003 (sharded flush): only shards dirtied since the last successful flush
         // are (re)serialized — clean shards are left untouched on disk, so cost scales
         // with dirty-entry count rather than total index size. Each dirty shard id is
         // popped from _dirtyShards BEFORE its content is read/written, so any mutation
         // landing concurrently (even mid-write) re-marks the shard dirty for the next
         // round instead of being silently dropped by an end-of-round clear.
-        private bool FlushVersionedSlot(SearchIndex snapshot, List<int> idsToWrite, long generation)
+        private void FlushVersionedSlot(SearchIndex snapshot, List<int> idsToWrite, long generation)
         {
             string slots = _snapshotSlotsPath;
-            if (string.IsNullOrEmpty(slots)) return false;
+            if (string.IsNullOrEmpty(slots)) throw new InvalidOperationException("Index snapshot path is not initialized.");
             string slotName = "generation-" + generation + "-" + Guid.NewGuid().ToString("N");
             string tempSlot = Path.Combine(slots, ".rebuild-" + Guid.NewGuid().ToString("N"));
             string finalSlot = Path.Combine(slots, slotName);
@@ -1835,6 +1831,8 @@ namespace GxMcp.Worker.Services
                     if (idsToWrite.Contains(id)) _shardWriteCounts.AddOrUpdate(id, 1, (k, v) => v + 1);
                 }
 
+                // Do not inherit the previous generation's enrichment certificate.
+                // Its caller must certify this body with WriteMetaSidecar after enrichment/delta completes.
                 WriteShardManifestAt(tempSlot, snapshot.Objects.Count);
                 Directory.Move(tempSlot, finalSlot);
                 string pointerTemp = _snapshotPointerPath + ".tmp-" + Guid.NewGuid().ToString("N");
@@ -1855,13 +1853,6 @@ namespace GxMcp.Worker.Services
                             Directory.Delete(directory, true);
                 }
                 catch (Exception cleanup) { Logger.Warn("Snapshot slot cleanup deferred: " + cleanup.Message); }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                _lastFlushErrorMessage = ex.Message;
-                Logger.Error("Versioned index snapshot failed: " + ex.ToString());
-                return false;
             }
             finally { try { if (Directory.Exists(tempSlot)) Directory.Delete(tempSlot, true); } catch { } }
         }
@@ -1879,6 +1870,8 @@ namespace GxMcp.Worker.Services
             File.WriteAllText(Path.Combine(directory, "manifest.json"), Newtonsoft.Json.JsonConvert.SerializeObject(manifest), new UTF8Encoding(false));
         }
 
+        // Returns true only after publishing the captured generation. Failures retain
+        // dirty shards for retry and return false; they never certify the old bytes.
         private bool FlushToDisk()
         {
             if (_savingInProgress) return false;
@@ -1906,7 +1899,7 @@ namespace GxMcp.Worker.Services
 
             try
             {
-                if (!FlushVersionedSlot(snapshot, idsToWrite, gen)) return false;
+                FlushVersionedSlot(snapshot, idsToWrite, gen);
                 System.Threading.Interlocked.Exchange(ref _consecutiveFlushFailures, 0);
                 _lastFlushSuccessUtc = DateTime.UtcNow;
                 _lastFlushErrorMessage = null;
@@ -1917,8 +1910,8 @@ namespace GxMcp.Worker.Services
                 return true;
             }
             catch (Exception ex) {
-                // Round-level failure (e.g. directory creation) before/around the per-shard
-                // loop — restore every popped id so nothing is lost.
+                // Includes failed certified-pointer publication: the old generation is
+                // still current, so every popped shard must be retried with its new bytes.
                 foreach (var id in idsToWrite) _dirtyShards[id] = 1;
                 int n = System.Threading.Interlocked.Increment(ref _consecutiveFlushFailures);
                 _lastFlushErrorMessage = ex.Message;

--- a/src/GxMcp.Worker/Services/ObjectReader.cs
+++ b/src/GxMcp.Worker/Services/ObjectReader.cs
@@ -136,6 +136,10 @@ namespace GxMcp.Worker.Services
             _objectService?.MarkReadCacheDirty(null, part);
         }
 
+        // An isolated object transaction can be addressed through different names,
+        // GUIDs and paths. These request keys have no reverse identity index.
+        internal static void InvalidateAll() => _cache.Clear();
+
         public bool TryGetCached(string target, string part, int? offset, int? limit, string client, out string cachedJson)
         {
             var req = new ObjectReadRequest

--- a/src/GxMcp.Worker/Services/ObjectService.cs
+++ b/src/GxMcp.Worker/Services/ObjectService.cs
@@ -3600,6 +3600,10 @@ namespace GxMcp.Worker.Services
             return Models.McpResponse.Ok(target: obj.Name, code: "FullObjectRead", result: result);
         }
 
+        // Managed cache only: safe even when an interrupted SDK save poisoned the
+        // session. Strict persisted-state verification uses the public SDK cache API.
+        internal static void InvalidateAllReadCaches() => _readCache.Clear();
+
         public void MarkReadCacheDirty(KBObject obj, string partName = null)
         {
             if (obj == null)

--- a/src/GxMcp.Worker/Services/PatchService.cs
+++ b/src/GxMcp.Worker/Services/PatchService.cs
@@ -339,7 +339,7 @@ namespace GxMcp.Worker.Services
                             return BuildPatchResult("Error", partName, normalizedOperation, expectedCount, 0,
                                 "Replace needs the text to find. Use mode=patch with operation=\"Replace\", context=\"<exact existing lines>\", content=\"<new lines>\" — or the shorthand patch={\"find\":\"<existing>\",\"replace\":\"<new>\"}. A bare patch string / content-only has nothing to match against.");
 
-                        if (NormalizeSourceForComparison(workContext) == NormalizeSourceForComparison(workContent))
+                        if (!requireObjectSave && NormalizeSourceForComparison(workContext) == NormalizeSourceForComparison(workContent))
                         {
                             return BuildPatchResult("NoChange", partName, normalizedOperation, expectedCount, 1, "Patch content is identical to context. Write skipped.");
                         }
@@ -572,7 +572,8 @@ namespace GxMcp.Worker.Services
                     return AttachTimings(failure, readMs, patchMs, 0, sourceFromCache);
                 }
 
-                if (NormalizeForPartCompare(partName, workSource) == NormalizeForPartCompare(partName, updatedSource))
+                bool noContentChange = NormalizeForPartCompare(partName, workSource) == NormalizeForPartCompare(partName, updatedSource);
+                if (noContentChange && !requireObjectSave)
                 {
                     // Friction 2026-05-22: distinguish the two NoChange cases.
                     // case-a: matched + content identical to context (caught earlier
@@ -599,6 +600,11 @@ namespace GxMcp.Worker.Services
                     catch { }
                     return AttachTimings(noChange, readMs, patchMs, 0, sourceFromCache);
                 }
+
+                // Events may already have been saved only as a part. Requiring the
+                // object save still means ForceSave + verification when the text is
+                // unchanged. Preserve its exact bytes instead of normalizing again.
+                if (noContentChange) updatedSource = workSource;
 
                 bool commentOnlyChange = CommentOnlyPatch.TryClassify(
                     partName, normalizedOperation, workContext, workContent, out string commentStyle);
@@ -634,13 +640,20 @@ namespace GxMcp.Worker.Services
                     {
                         var dryRunJson = JObject.Parse(dryRunResult);
                         var dryRunBody = dryRunJson["result"] as JObject ?? dryRunJson;
-                        var dryRunEvidence = TextPersistenceVerifier.Evaluate(requested: updatedSource.Replace("\n", Environment.NewLine), persisted: originalSource, requestedMode: resolvedVerifyMode, partName: partName);
+                        var dryRunEvidence = TextPersistenceVerifier.Evaluate(
+                            requested: requireObjectSave && noContentChange ? originalSource : ToSdkLineEndings(updatedSource),
+                            persisted: originalSource, requestedMode: resolvedVerifyMode, partName: partName);
                         dryRunBody["persisted"] = false;
                         dryRunBody["saved"] = false;
                         dryRunBody["verified"] = false;
                         dryRunBody["requireObjectSave"] = requireObjectSave;
+                        dryRunBody["noContentChange"] = noContentChange;
                         if (requireObjectSave)
-                            dryRunBody["writeBlocker"] = "ObjectSaveIsolationUnverified";
+                        {
+                            var isolation = _writeService.InspectEventsIsolation(target, typeFilter);
+                            dryRunBody["objectSaveIsolation"] = isolation;
+                            if (isolation["blocker"] != null) dryRunBody["writeBlocker"] = isolation["blocker"];
+                        }
                         dryRunBody["requestedHash"] = dryRunEvidence.RequestedHash;
                         dryRunBody["persistedHash"] = dryRunEvidence.PersistedHash;
                         dryRunBody["commentOnly"] = commentOnlyChange;
@@ -755,11 +768,17 @@ namespace GxMcp.Worker.Services
                             extra: new JObject { ["baseVersion"] = baseVersion, ["currentVersion"] = currentVersion });
                 }
 
-                string isolationError = PatchPersistenceReceipt.ObjectSaveIsolationGuard(target, requireObjectSave, dryRun);
-                if (isolationError != null) return isolationError;
+                if (requireObjectSave)
+                {
+                    var requiredSaveWatch = Stopwatch.StartNew();
+                    string requiredSave = _writeService.WriteIsolatedEvents(target,
+                        noContentChange ? originalSource : ToSdkLineEndings(updatedSource), typeFilter, baseVersion);
+                    requiredSaveWatch.Stop();
+                    return AttachTimings(requiredSave, readMs, patchMs, requiredSaveWatch.ElapsedMilliseconds, sourceFromCache);
+                }
 
                 // 3. Write Back (re-normalize to CRLF for GeneXus)
-                string finalCode = updatedSource.Replace("\n", Environment.NewLine);
+                string finalCode = ToSdkLineEndings(updatedSource);
                 ObjectMetadataSnapshot metadataBefore = null;
                 ObjectMoveSnapshot fullObjectSnapshot = null;
                 if (requireObjectSave && !dryRun)
@@ -1092,6 +1111,12 @@ namespace GxMcp.Worker.Services
             return text.Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd('\n');
         }
 
+        private static string ToSdkLineEndings(string text)
+        {
+            return (text ?? string.Empty).Replace("\r\n", "\n").Replace("\r", "\n")
+                .Replace("\n", Environment.NewLine);
+        }
+
         // Friction-report #5 write-side: VariablesPart's underlying SDK collection inserts new
         // variables at the FRONT of the list, so a patch that produced `<original>...\n&NewVar`
         // round-trips through SetVariablesFromText / GetVariablesAsText as
@@ -1413,6 +1438,8 @@ namespace GxMcp.Worker.Services
                 PatchLanded = false
             };
         }
+
+        internal static void InvalidateAllSourceCaches() => _sourceCache.Clear();
 
         public static void InvalidateCachedSource(string target, string partName, string typeFilter)
         {

--- a/src/GxMcp.Worker/Services/TypeIntrospectService.cs
+++ b/src/GxMcp.Worker/Services/TypeIntrospectService.cs
@@ -39,13 +39,13 @@ namespace GxMcp.Worker.Services
                     case "validate_value":
                         return RunValidateValue(args?["type"]?.ToString(), args?["value"]?.ToString());
                     default:
-                        return ErrorJson($"Unknown action '{action}'. Expected list|describe|validate_value.");
+                        return ErrorJson("InvalidAction", $"Unknown action '{action}'. Expected list|describe|validate_value.");
                 }
             }
             catch (Exception ex)
             {
                 Logger.Error("TypeIntrospectService.Run: " + ex.Message);
-                return ErrorJson(ex.Message);
+                return ErrorJson("TypeIntrospectFailed", ex.Message);
             }
         }
 
@@ -107,9 +107,9 @@ namespace GxMcp.Worker.Services
 
         private string RunDescribe(string name)
         {
-            if (string.IsNullOrWhiteSpace(name)) return ErrorJson("name required for action=describe.");
+            if (string.IsNullOrWhiteSpace(name)) return ErrorJson("InvalidArgument", "name required for action=describe.");
             var info = ReadDomainInfo(name);
-            if (info == null) return ErrorJson($"Type '{name}' not found or not a Domain.");
+            if (info == null) return ErrorJson("TypeNotFound", $"Domain '{name}' was not found.");
 
             var payload = new JObject
             {
@@ -149,9 +149,9 @@ namespace GxMcp.Worker.Services
 
         private string RunValidateValue(string typeName, string value)
         {
-            if (string.IsNullOrWhiteSpace(typeName)) return ErrorJson("type required for action=validate_value.");
+            if (string.IsNullOrWhiteSpace(typeName)) return ErrorJson("InvalidArgument", "type required for action=validate_value.");
             var info = ReadDomainInfo(typeName);
-            if (info == null) return ErrorJson($"Type '{typeName}' not found or not a Domain.");
+            if (info == null) return ErrorJson("TypeNotFound", $"Domain '{typeName}' was not found.");
             var r = ValidateValue(info, value);
             return McpResponse.Ok(code: "TypeIntrospected", result: r);
         }
@@ -268,7 +268,7 @@ namespace GxMcp.Worker.Services
             if (_objectService == null) return null;
             try
             {
-                dynamic obj = _objectService.FindObject(name);
+                dynamic obj = _objectService.FindObject(name, "Domain");
                 if (obj == null) return null;
                 string td = "";
                 try { td = (string)obj.TypeDescriptor.Name; } catch { }
@@ -286,31 +286,8 @@ namespace GxMcp.Worker.Services
                 try { info.Decimals = (int?)obj.Decimals; } catch { }
                 try { info.Signed = (bool?)obj.Signed; } catch { }
 
-                // EnumValues — best-effort. Domain has IPropertyBag-style accessor.
-                try
-                {
-                    dynamic evs = null;
-                    try { evs = obj.EnumValues; } catch { }
-                    if (evs != null)
-                    {
-                        var list = new List<DomainEnumValueRecord>();
-                        try
-                        {
-                            foreach (dynamic ev in evs.Values)
-                            {
-                                list.Add(new DomainEnumValueRecord
-                                {
-                                    Name = (string)ev.Name,
-                                    Value = ev.Value?.ToString(),
-                                    Description = ev.Description?.ToString()
-                                });
-                            }
-                        }
-                        catch { }
-                        if (list.Count > 0) info.AllowedValues = list;
-                    }
-                }
-                catch { }
+                var enumValues = ReadDomainEnumValues((object)obj);
+                if (enumValues.Count > 0) info.AllowedValues = enumValues;
 
                 return info;
             }
@@ -321,9 +298,41 @@ namespace GxMcp.Worker.Services
             }
         }
 
-        private static string ErrorJson(string message)
+        public static List<DomainEnumValueRecord> ReadDomainEnumValues(object domain)
         {
-            return McpResponse.Err(code: "TypeIntrospectFailed", message: message);
+            var result = new List<DomainEnumValueRecord>();
+            if (domain == null) return result;
+
+            try
+            {
+                dynamic valueSource = domain;
+                foreach (dynamic value in valueSource.EnumValues)
+                {
+                    result.Add(new DomainEnumValueRecord
+                    {
+                        Name = value.Name?.ToString(),
+                        Value = value.Value?.ToString(),
+                        Description = value.Description?.ToString()
+                    });
+                }
+            }
+            catch { }
+
+            if (result.Count > 0) return result;
+            return DomainPropertyApplier.ReadEnumValues(domain)
+                .OfType<JObject>()
+                .Select(value => new DomainEnumValueRecord
+                {
+                    Name = value["name"]?.ToString(),
+                    Value = value["value"]?.ToString(),
+                    Description = value["description"]?.ToString()
+                })
+                .ToList();
+        }
+
+        private static string ErrorJson(string code, string message)
+        {
+            return McpResponse.Err(code: code, message: message);
         }
 
         private static string EdbToCanonical(string edb)

--- a/src/GxMcp.Worker/Services/WriteService.EventsIsolation.cs
+++ b/src/GxMcp.Worker/Services/WriteService.EventsIsolation.cs
@@ -1,0 +1,308 @@
+using System;
+using Artech.Architecture.Common.Objects;
+using Artech.Genexus.Common.Objects;
+using GxMcp.Worker.Helpers;
+using GxMcp.Worker.Models;
+using Newtonsoft.Json.Linq;
+
+namespace GxMcp.Worker.Services
+{
+    public partial class WriteService
+    {
+        internal JObject InspectEventsIsolation(string target, string typeFilter)
+        {
+            using (SdkGate.Enter())
+            {
+                try { return EventsSaveIsolation.Preflight(_objectService.FindObject(target, typeFilter)); }
+                catch (Exception ex) { return new JObject { ["verified"] = false, ["blocker"] = "ObjectSaveIsolationUnverified", ["reason"] = ex.Message }; }
+            }
+        }
+
+        internal string WriteIsolatedEvents(string target, string source, string typeFilter, string baseVersion)
+        {
+            using (SdkGate.Enter())
+            {
+                var receipt = new JObject();
+                KBObject verifiedState;
+                Guid guid;
+                string response;
+                try
+                {
+                    response = WriteIsolatedEventsCore(target, source, typeFilter, baseVersion, receipt, out verifiedState, out guid);
+                }
+                finally
+                {
+                    // Rollback and interrupted Save also leave cached SDK-derived
+                    // reads stale. Invalidate every alias without touching the SDK.
+                    if (receipt["mutationAttempted"]?.Value<bool>() == true)
+                        InvalidateIsolatedEventsReadCaches();
+                }
+
+                if (receipt["mutationAttempted"]?.Value<bool>() != true) return response;
+                var envelope = JObject.Parse(response);
+                var body = envelope["result"] as JObject ?? envelope;
+                body["readCachesInvalidated"] = true;
+                bool dirty = ShouldMarkIsolatedEventsDirty(receipt);
+                if (dirty) NotePerTargetWrite(target);
+                body["targetMarkedDirty"] = dirty;
+                try
+                {
+                    var index = _objectService.GetKbService()?.GetIndexCache();
+                    // Drop the old entry first. Never refresh from the pre-save seed
+                    // or from a speculative in-transaction instance.
+                    if (index?.TryGetLoadedIndex() != null) index.RemoveEntryByGuid(guid.ToString());
+                    if (verifiedState != null && !SdkEventSuppressionScope.IsPoisoned)
+                    {
+                        index?.UpdateEntry(verifiedState);
+                        body["indexRefresh"] = index == null ? "unavailable" : "fresh-sdk-state";
+                    }
+                    else body["indexRefresh"] = index?.TryGetLoadedIndex() == null ? "not-loaded" : "entry-invalidated";
+                }
+                catch (Exception ex)
+                {
+                    // A cache refresh must not hide a committed/partial save receipt.
+                    body["indexRefreshError"] = ex.Message;
+                }
+                return envelope.ToString();
+            }
+        }
+
+        internal static void InvalidateIsolatedEventsReadCaches()
+        {
+            PatchService.InvalidateAllSourceCaches();
+            ObjectReader.InvalidateAll();
+            ObjectService.InvalidateAllReadCaches();
+            ListService.InvalidateCache();
+            SummarizeService.InvalidateCache();
+        }
+
+        // Mirrors WriteObject's outcome-based dirty tracking: refusal, verified
+        // rollback and a verified content no-op stay clean; uncertain persistence
+        // remains dirty. This path returns a canonical envelope, not WriteApplied.
+        internal static bool ShouldMarkIsolatedEventsDirty(JObject receipt)
+        {
+            if (receipt?["writeAttempted"]?.Value<bool>() != true
+                || receipt["rollbackVerified"]?.Value<bool>() == true) return false;
+            bool verifiedNoContentChange = receipt["verificationCompleted"]?.Value<bool>() == true
+                && receipt["objectSaved"]?.Value<bool>() == true
+                && receipt["partPersisted"]?.Value<bool>() == true
+                && receipt["otherPartsIntact"]?.Value<bool>() == true
+                && receipt["otherObjectMetadataIntact"]?.Value<bool>() == true
+                && receipt["sourceChanged"]?.Value<bool?>() == false
+                && receipt["persistenceUncertain"]?.Value<bool>() != true;
+            return !verifiedNoContentChange;
+        }
+
+        private string WriteIsolatedEventsCore(string target, string source, string typeFilter, string baseVersion,
+            JObject receipt, out KBObject verifiedState, out Guid guid)
+        {
+            verifiedState = null;
+            guid = Guid.Empty;
+            using (SdkGate.Enter())
+            {
+                KBObject seed = _objectService.FindObject(target, typeFilter);
+                JObject isolation;
+                try { isolation = EventsSaveIsolation.Preflight(seed); }
+                catch (Exception ex)
+                {
+                    return McpResponse.Err(code: "ObjectSaveIsolationUnverified", target: target,
+                        message: ex.Message, extra: new JObject { ["writeAttempted"] = false, ["partPersisted"] = false, ["objectSaved"] = false });
+                }
+                var kb = seed.KB;
+                guid = seed.Guid;
+                receipt.Merge(new JObject
+                {
+                    ["requireObjectSave"] = true, ["persistencePath"] = "sdk_object_force_save_isolated",
+                    ["isolation"] = isolation, ["writeAttempted"] = false,
+                    ["objectSaveInvoked"] = false, ["objectSaved"] = false, ["partPersisted"] = false,
+                    ["metadataUpdated"] = false, ["metadataStampPersisted"] = false,
+                    ["implicitOperations"] = new JArray(), ["retrySafe"] = false
+                });
+                bool committed = false;
+                try
+                {
+                // The audited U16 callback chain must run for a complete object
+                // save; suppressing it prevents the Events source from being
+                // materialized by the SDK. Preflight fingerprints every loaded
+                // callback assembly, while the pattern scope disables only the
+                // known WWP reapplication path.
+                using (KbWatcherService.AcquireWriteGate())
+                {
+                    var original = EventsSaveIsolation.Fresh(kb, guid);
+                    string originalSource = EventsSaveIsolation.Source(original);
+                    receipt["sourceChanged"] = !string.Equals(originalSource, source, StringComparison.Ordinal);
+                    string originalToken = EventsSaveIsolation.Token(original);
+                    string originalPlacement = EventsSaveIsolation.Placement(original);
+                    var revisionBefore = original.VersionId;
+                    var lastUpdateBefore = original.LastUpdate;
+                    if (string.IsNullOrWhiteSpace(baseVersion) || originalToken != baseVersion)
+                        return McpResponse.Err(code: "VersionConflict", target: target,
+                            message: "The Events version changed; no save was attempted.",
+                            extra: new JObject { ["currentVersion"] = originalToken, ["writeAttempted"] = false });
+                    var snapshot = ObjectMoveSnapshot.Capture(original);
+                    var inventory = EventsSaveIsolation.Inventory(kb);
+                    receipt["inventoryCount"] = inventory.Count;
+                    receipt["inventoryComplete"] = true;
+                    receipt["revisionBefore"] = revisionBefore;
+                    receipt["lastUpdateBefore"] = lastUpdateBefore.ToUniversalTime().ToString("o");
+                    string failure = null;
+                    using (var transaction = kb.BeginTransaction())
+                    {
+                        try
+                        {
+                            var current = EventsSaveIsolation.Fresh(kb, guid);
+                            if (EventsSaveIsolation.Token(current) != originalToken)
+                            {
+                                transaction.Rollback();
+                                return McpResponse.Err(code: "VersionConflict", target: target,
+                                    message: "The Events version changed at the transaction boundary; no save was attempted.",
+                                    extra: new JObject { ["currentVersion"] = EventsSaveIsolation.Token(current), ["writeAttempted"] = false });
+                            }
+                            EventsSaveIsolation.CheckTarget(current);
+                            receipt["mutationAttempted"] = true;
+                            var eventsPart = GxMcp.Worker.Structure.PartAccessor.GetPart(current, "Events");
+                            if (!(eventsPart is ISource eventsSource)) throw new InvalidOperationException("The audited WebPanel does not expose an Events source part.");
+                            eventsSource.Source = source;
+                            receipt["sourceAfterSetLength"] = (eventsSource.Source ?? string.Empty).Length;
+                            receipt["sourceAfterSetMatch"] = EventsSaveIsolation.SourceEquivalent(eventsSource.Source, source);
+                            receipt["writeAttempted"] = true;
+                            receipt["objectSaveInvoked"] = true;
+                            // Timestamp is independent of dirty classification, as in
+                            // WriteObject. It records the attempt even after rollback.
+                            if (!string.IsNullOrWhiteSpace(target)) _lastWriteAtUtc[target] = DateTime.UtcNow;
+                            PatternSaveIsolationScope patternScope = null;
+                            try
+                            {
+                                patternScope = new PatternSaveIsolationScope(current);
+                                receipt["patternSaveIsolation"] = new JObject
+                                {
+                                    ["skipApplyPatternSet"] = true,
+                                    ["wasAlreadySet"] = patternScope.WasAlreadySet
+                                };
+                                // Persist the authored Events part first, then invoke
+                                // the complete object Save in the same transaction.
+                                // U16 can refresh the in-memory Events projection while
+                                // the object save runs, so retain the part-save state
+                                // for the pre-commit assertion and prove persistence
+                                // with the fresh read after commit.
+                                eventsPart.Save();
+                                string sourceAfterPartSave = EventsSaveIsolation.Source(current);
+                                receipt["eventsPartSaveInvoked"] = true;
+                                receipt["sourceAfterPartSaveLength"] = sourceAfterPartSave.Length;
+                                receipt["sourceAfterPartSaveMatch"] = EventsSaveIsolation.SourceEquivalent(sourceAfterPartSave, source);
+                                current.Save(new KBObjectSavePreferences
+                                {
+                                    ForceSave = true, ForceSaveDefaultParts = false,
+                                    SkipValidation = true, UpdateParentModels = false
+                                });
+                                string sourceAfterObjectSave = EventsSaveIsolation.Source(current);
+                                receipt["preCommitPartSourceMatch"] = EventsSaveIsolation.SourceEquivalent(sourceAfterPartSave, source);
+                                receipt["preCommitObjectSourceMatch"] = EventsSaveIsolation.SourceEquivalent(sourceAfterObjectSave, source);
+                            }
+                            finally
+                            {
+                                if (patternScope != null)
+                                {
+                                    patternScope.Dispose();
+                                    ((JObject)receipt["patternSaveIsolation"])["skipApplyPatternRestored"] = patternScope.Restored;
+                                }
+                            }
+                            receipt["objectSaveReturned"] = true;
+                            // U16 can expose a new cache instance with an empty
+                            // Events projection until the surrounding SDK
+                            // transaction commits. Verify the object that just
+                            // completed Save before commit; the mandatory fresh
+                            // read after transaction disposal is the persistence
+                            // proof below.
+                            var comparison = snapshot.Compare(current, "Events");
+                            var changedOthers = EventsSaveIsolation.ChangedOthers(inventory, EventsSaveIsolation.Inventory(kb), guid);
+                            receipt["preCommitObjectStateVerified"] = true;
+                            receipt["preCommitFreshReadDeferred"] = true;
+                            receipt["preCommitSourceMatch"] = receipt["preCommitPartSourceMatch"]?.Value<bool>() == true;
+                            receipt["preCommitSourceLength"] = EventsSaveIsolation.Source(current).Length;
+                            receipt["requestedSourceLength"] = source.Length;
+                            receipt["preCommitSourceHash"] = EventsSaveIsolation.ContentHash(EventsSaveIsolation.Source(current));
+                            receipt["requestedSourceHash"] = EventsSaveIsolation.ContentHash(source);
+                            receipt["preCommitOtherPartsIntact"] = comparison.Equal;
+                            bool preCommitPatternProjectionAllowed = isolation["patternPart"]?.Value<bool>() == true
+                                && EventsSaveIsolation.IsExpectedPatternProjection(comparison);
+                            receipt["preCommitPatternProjectionAllowed"] = preCommitPatternProjectionAllowed;
+                            receipt["preCommitPlacementMatch"] = EventsSaveIsolation.Placement(current) == originalPlacement;
+                            receipt["preCommitChangedObjectProperties"] = comparison.ChangedParts;
+                            receipt["preCommitChangedPartKeys"] = new JArray(comparison.ChangedPartKeys);
+                            receipt["preCommitChangedPartDeltas"] = snapshot.DescribeDifferences(current, "Events");
+                            receipt["unexpectedChangedParts"] = comparison.ChangedParts;
+                            receipt["unexpectedChangedObjects"] = changedOthers;
+                            if (receipt["preCommitSourceMatch"]?.Value<bool>() != true
+                                || (!comparison.Equal && !preCommitPatternProjectionAllowed)
+                                || changedOthers.Count != 0
+                                || EventsSaveIsolation.Placement(current) != originalPlacement)
+                                throw new InvalidOperationException("The pre-commit SDK object state did not match the requested isolated change.");
+                            transaction.Commit();
+                            committed = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            failure = ex.Message;
+                            try { transaction.Rollback(); receipt["transactionRolledBack"] = true; }
+                            catch (Exception rollbackEx) { receipt["rollbackError"] = rollbackEx.Message; }
+                        }
+                    }
+                    // Mandatory fresh verification occurs after transaction disposal,
+                    // while broker suppression remains in force. No compensating Save.
+                    var persisted = EventsSaveIsolation.Fresh(kb, guid);
+                    int postCommitReadAttempts = 1;
+                    if (!EventsSaveIsolation.SourceEquivalent(EventsSaveIsolation.Source(persisted), source))
+                    {
+                        // The first U16 cache refresh can race the transaction's
+                        // post-commit projection. A second fresh SDK instance is
+                        // a read-only reconciliation, never a second write.
+                        persisted = EventsSaveIsolation.Fresh(kb, guid);
+                        postCommitReadAttempts++;
+                    }
+                    var finalComparison = snapshot.Compare(persisted, "Events");
+                    var finalOthers = EventsSaveIsolation.ChangedOthers(inventory, EventsSaveIsolation.Inventory(kb), guid);
+                    bool partPersisted = EventsSaveIsolation.SourceEquivalent(EventsSaveIsolation.Source(persisted), source);
+                    bool metadataAdvanced = persisted.VersionId > revisionBefore || persisted.LastUpdate > lastUpdateBefore;
+                    bool otherPartsIntact = finalComparison.Equal && EventsSaveIsolation.Placement(persisted) == originalPlacement;
+                    receipt["partPersisted"] = partPersisted;
+                    receipt["objectSaved"] = committed;
+                    receipt["metadataUpdated"] = committed && metadataAdvanced;
+                    receipt["metadataEvidence"] = "fresh-sdk-read-after-object-save";
+                    receipt["postCommitReadAttempts"] = postCommitReadAttempts;
+                    receipt["otherPartsIntact"] = otherPartsIntact;
+                    receipt["unexpectedChangedParts"] = finalComparison.ChangedParts;
+                    receipt["unexpectedChangedObjects"] = finalOthers;
+                    receipt["otherObjectMetadataIntact"] = finalOthers.Count == 0;
+                    receipt["revisionAfter"] = persisted.VersionId;
+                    receipt["lastUpdateAfter"] = persisted.LastUpdate.ToUniversalTime().ToString("o");
+                    receipt["versionToken"] = EventsSaveIsolation.Token(persisted);
+                    receipt["reReadConfirmed"] = partPersisted;
+                    receipt["persisted"] = partPersisted;
+                    receipt["saved"] = committed;
+                    receipt["rollbackVerified"] = !committed && EventsSaveIsolation.SourceEquivalent(EventsSaveIsolation.Source(persisted), originalSource)
+                        && otherPartsIntact && finalOthers.Count == 0
+                        && persisted.VersionId == revisionBefore && persisted.LastUpdate == lastUpdateBefore;
+                    receipt["verificationCompleted"] = true;
+                    verifiedState = persisted;
+                    if (committed && partPersisted && metadataAdvanced && otherPartsIntact && finalOthers.Count == 0)
+                        return McpResponse.Ok(code: "Applied", target: target, result: receipt);
+                    return McpResponse.Err(code: "ObjectSaveIncomplete", target: target,
+                        message: failure ?? "Complete isolated object persistence could not be confirmed. Inspect the returned persistence state; do not retry blindly.",
+                        extra: receipt);
+                }
+                }
+                catch (Exception ex)
+                {
+                    receipt["objectSaved"] = committed;
+                    receipt["verificationCompleted"] = false;
+                    receipt["persistenceUncertain"] = receipt["writeAttempted"]?.Value<bool>() == true;
+                    receipt["partPersisted"] = JValue.CreateNull();
+                    receipt["workerRestartRequired"] = SdkEventSuppressionScope.IsPoisoned;
+                    return McpResponse.Err(code: "ObjectSaveIncomplete", target: target,
+                        message: "SDK persistence or verification was interrupted: " + ex.Message + ". No compensating write was performed.", extra: receipt);
+                }
+            }
+        }
+    }
+}

--- a/src/GxMcp.Worker/Services/WwpProjectionHelper.cs
+++ b/src/GxMcp.Worker/Services/WwpProjectionHelper.cs
@@ -70,6 +70,8 @@ namespace GxMcp.Worker.Services
                 object buildProcess = getBuildProcess.Invoke(impl, null);
                 if (buildProcess == null) { Logger.Debug("[WWP-PROJECT] GetBuildProcess returned null"); return false; }
 
+                RefreshHostStateForProjection(host);
+
                 var updateParent = buildProcess.GetType().GetMethod("UpdateParentObject",
                     BindingFlags.Public | BindingFlags.Instance);
                 if (updateParent == null) { Logger.Debug("[WWP-PROJECT] UpdateParentObject() not found"); return false; }
@@ -129,6 +131,32 @@ namespace GxMcp.Worker.Services
                 Logger.Warn("[WWP-PROJECT] failed: " + ex.Message);
                 return false;
             }
+        }
+
+        private static void RefreshHostStateForProjection(KBObject host)
+        {
+            if (host == null) return;
+            var flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            foreach (string methodName in new[] { "RefreshDefaultDependentParts", "Reload", "Refresh", "Reset" })
+            {
+                try
+                {
+                    var method = host.GetType().GetMethod(methodName, flags, null, Type.EmptyTypes, null);
+                    if (method == null) continue;
+                    method.Invoke(host, null);
+                    Logger.Info("[WWP-PROJECT] Refreshed host state via " + methodName + " before projection.");
+                    return;
+                }
+                catch (TargetInvocationException tie)
+                {
+                    Logger.Debug("[WWP-PROJECT] Host " + methodName + " skipped: " + (tie.InnerException?.Message ?? tie.Message));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Debug("[WWP-PROJECT] Host " + methodName + " skipped: " + ex.Message);
+                }
+            }
+            Logger.Debug("[WWP-PROJECT] No host refresh method was available before projection.");
         }
 
         // Best-effort invoke for IPatternBuildProcess lifecycle hooks that take


### PR DESCRIPTION
## Summary
- Integrates the validated changes from #167, #168 and #169 against the current main.
- Resolves the fork-branch conflicts in CHANGELOG.md and SDK compatibility documentation/tests.
- Hardens Events save isolation: part names alone no longer authorize Rules/Conditions projections, and pre-commit verification requires the post-Object.Save source match.

## Validation
- Focused Worker tests: 49/49 passed.
- Full Worker suite: 2652 passed, 4 skipped, 0 failed.
- Full Gateway suite: 1610 passed, 13 skipped, 0 failed.
- npm test: 114 passed, 0 failed.
- npm run lint: passed.
- Live/SDK checks remain skipped where the environment requires fixtures or installed SDK profiles.